### PR TITLE
bugfix: fixed NULL pointer reference in DMRecon::analyzeFeatures()

### DIFF
--- a/libs/dmrecon/DMRecon.cpp
+++ b/libs/dmrecon/DMRecon.cpp
@@ -172,7 +172,7 @@ void DMRecon::analyzeFeatures()
         for (std::size_t j = 0; j < features[i].refs.size(); ++j)
         {
             std::size_t id = features[i].refs[j].img_id;
-            if (views[id]->pointInFrustum(featurePos))
+            if (views[id] != NULL && views[id]->pointInFrustum(featurePos))
                 views[id]->addFeature(i);
         }
     }


### PR DESCRIPTION
If there are bad rotation matrix, some views aren't copied to scene/views/.
So, some views[id] get NULL pointer and segmentation fault is occured.
