### PR TITLE
Selection of rotation center

### DIFF
--- a/libs/ogl/camtrackball.cc
+++ b/libs/ogl/camtrackball.cc
@@ -122,7 +122,7 @@ CamTrackball::handle_tb_rotation (int x, int y)
 math::Vec3f
 CamTrackball::get_center (int x, int y)
 {
-    /* patchsize should be odd and larger than one */
+    /* Patchsize should be odd and larger than one. */
     int const patchsize = 9;
     int const half_patchsize = patchsize / 2;
 


### PR DESCRIPTION
Hi Simon,
because pointclouds of reconstructed scenes may be really sparse i changed the selection method of the rotation center from just requesting a single depth value to a area(square) in order to make selections easier.
Cheers
    nils
