### PR TITLE
cache image pyramids

### DIFF
--- a/libs/dmrecon/DMRecon.cpp
+++ b/libs/dmrecon/DMRecon.cpp
@@ -55,15 +55,15 @@ DMRecon::DMRecon(mve::Scene::Ptr _scene, Settings const& _settings)
     {
         if ((mve_views[i] == NULL) || !mve_views[i]->is_camera_valid())
             continue;
-        mvs::SingleView::Ptr sView(new mvs::SingleView(mve_views[i]));
+        mvs::SingleView::Ptr sView(new mvs::SingleView(scene, mve_views[i]));
         views[i] = sView;
     }
     SingleView::Ptr refV = views[refViewNr];
 
     /* Prepare reconstruction */
-    refV->loadColorImage(this->settings.imageEmbedding);
+    refV->loadColorImage(this->settings.imageEmbedding, settings.scale);
     refV->prepareRecon(settings.scale);
-    mve::ImageBase::Ptr scaled_img = refV->getScaledImg();
+    mve::ImageBase::ConstPtr scaled_img = refV->getScaledImg();
     this->width = scaled_img->width();
     this->height = scaled_img->height();
 
@@ -152,7 +152,7 @@ void DMRecon::start()
         if (settings.scale != 0) {
             name = "undist-L";
             name += util::string::get(settings.scale);
-            view->set_image(name, refV->getScaledImg());
+            view->set_image(name, refV->getScaledImg()->duplicate());
         }
 
         progress.status = RECON_IDLE;
@@ -231,7 +231,7 @@ void DMRecon::globalViewSelection()
          && !progress.cancelled; ++citID)
     {
         ss << *citID << " ";
-        views[*citID]->loadColorImage(this->settings.imageEmbedding);
+        views[*citID]->loadColorImage(this->settings.imageEmbedding, 0);
     }
     ss << std::endl;
     std::cout << ss.str();

--- a/libs/dmrecon/ImagePyramid.cpp
+++ b/libs/dmrecon/ImagePyramid.cpp
@@ -1,0 +1,176 @@
+#include "dmrecon/ImagePyramid.h"
+
+#include "mve/imagetools.h"
+
+MVS_NAMESPACE_BEGIN
+
+namespace
+{
+    int const MIN_IMAGE_DIM = 30;
+
+    ImagePyramid::Ptr
+    buildPyramid(mve::View::Ptr view, std::string embeddingName)
+    {
+        ImagePyramid::Ptr pyramid(new ImagePyramid());
+        ImagePyramid& levels = *pyramid;
+
+        mve::MVEFileProxy const* proxy = view->get_proxy(embeddingName);
+        mve::CameraInfo cam = view->get_camera();
+
+        int curr_width = proxy->width;
+        int curr_height = proxy->height;
+
+        levels.push_back(ImagePyramidLevel(cam, curr_width, curr_height));
+
+        while (std::min(curr_width, curr_height) >= MIN_IMAGE_DIM)
+        {
+            if (curr_width % 2 == 1)
+                cam.ppoint[0] = cam.ppoint[0] * float(curr_width)
+                        / float(curr_width + 1);
+            if (curr_height % 2 == 1)
+                cam.ppoint[1] = cam.ppoint[1] * float(curr_height)
+                        / float(curr_height + 1);
+
+            curr_width = (curr_width + 1) / 2;
+            curr_height = (curr_height + 1) / 2;
+
+            levels.push_back(ImagePyramidLevel(cam, curr_width, curr_height));
+        }
+
+        return pyramid;
+    }
+
+    void
+    ensureImages(ImagePyramid& levels, mve::View::Ptr view,
+               std::string embeddingName, int minLevel)
+    {
+        if (levels[minLevel].image != NULL)
+            return;
+
+        mve::ImageBase::Ptr img = view->get_image(embeddingName);
+        int channels = img->channels();
+        mve::ImageType type = img->get_type();
+
+        switch (type)
+        {
+            case mve::IMAGE_TYPE_UINT8:
+                if (channels == 2 || channels == 4)
+                    mve::image::reduce_alpha<uint8_t>(img);
+                if (img->channels() == 1)
+                    img = mve::image::expand_grayscale<uint8_t>(img);
+                break;
+
+            case mve::IMAGE_TYPE_FLOAT:
+                if (channels == 2 || channels == 4)
+                    mve::image::reduce_alpha<float>(img);
+                if (img->channels() == 1)
+                    img = mve::image::expand_grayscale<float>(img);
+                break;
+
+            default:
+                throw util::Exception("Invalid image type");
+        }
+
+        if (img->channels() != 3)
+            throw std::invalid_argument("Image with invalid number of channels");
+
+        /* create image pyramid */
+        int curr_width = img->width();
+        int curr_height = img->height();
+
+        int i = 0;
+
+        if (0 >= minLevel)
+            levels[0].image = img;
+
+        while (std::min(curr_width, curr_height) >= MIN_IMAGE_DIM)
+        {
+            ++i;
+
+            if (levels[i].image != NULL)
+                break;
+
+            if (type == mve::IMAGE_TYPE_UINT8)
+                img = mve::image::rescale_half_size_gaussian<uint8_t>(img, 1.f);
+            else if (type == mve::IMAGE_TYPE_FLOAT)
+                img = mve::image::rescale_half_size_gaussian<float>(img, 1.f);
+            else
+                throw util::Exception("Invalid image type");
+
+            /* compute new projection matrix */
+            curr_width = img->width();
+            curr_height = img->height();
+
+            if (i >= minLevel)
+                levels[i].image = img;
+        }
+
+        view->cache_cleanup();
+    }
+
+}
+
+ImagePyramid::ConstPtr
+ImagePyramidCache::get(mve::Scene::Ptr scene, mve::View::Ptr view,
+                     std::string embeddingName, int minLevel)
+{
+    util::MutexLock lock(ImagePyramidCache::metadataMutex);
+
+    /* initialize on first access */
+    if (ImagePyramidCache::cachedScene == NULL)
+    {
+        std::cout << "initializing for scene " << &*scene << std::endl;
+        ImagePyramidCache::cachedScene = scene;
+        ImagePyramidCache::cachedEmbedding = embeddingName;
+    }
+
+    ImagePyramid::Ptr pyramid;
+
+    if (scene != ImagePyramidCache::cachedScene
+        || embeddingName != ImagePyramidCache::cachedEmbedding)
+    {
+        pyramid = buildPyramid(view, embeddingName);
+    }
+    else
+    {
+        pyramid = ImagePyramidCache::entries[view->get_id()];
+        if (pyramid == NULL)
+        {
+            pyramid = buildPyramid(view, embeddingName);
+            ImagePyramidCache::entries[view->get_id()] = pyramid;
+        }
+    }
+
+    ensureImages(*pyramid, view, embeddingName, minLevel);
+    return pyramid;
+}
+
+void
+ImagePyramidCache::cleanup()
+{
+    util::MutexLock lock(ImagePyramidCache::metadataMutex);
+
+    if (ImagePyramidCache::cachedScene == NULL)
+        return;
+
+    for (std::map<int, ImagePyramid::Ptr>::iterator it = ImagePyramidCache::entries.begin();
+         it != ImagePyramidCache::entries.end(); ++it)
+    {
+        if (it->second == NULL)
+            continue;
+
+        if (it->second.use_count() == 1)
+        {
+            it->second.reset();
+            ImagePyramidCache::cachedScene->get_view_by_id(it->first)->cache_cleanup();
+        }
+    }
+}
+
+/* static fields of ImgPyramidCache: */
+util::Mutex ImagePyramidCache::metadataMutex;
+mve::Scene::Ptr ImagePyramidCache::cachedScene;
+std::string ImagePyramidCache::cachedEmbedding = "";
+std::map<int, ImagePyramid::Ptr> ImagePyramidCache::entries;
+
+MVS_NAMESPACE_END

--- a/libs/dmrecon/ImagePyramid.h
+++ b/libs/dmrecon/ImagePyramid.h
@@ -1,0 +1,77 @@
+#ifndef DMRECON_IMAGEPYRAMID_H
+#define DMRECON_IMAGEPYRAMID_H
+
+#include <vector>
+#include <map>
+
+#include "mve/scene.h"
+#include "mve/view.h"
+#include "mve/imagebase.h"
+
+#include "mve/camera.h"
+#include "math/matrix.h"
+#include "util/refptr.h"
+#include "dmrecon/defines.h"
+#include "util/thread.h"
+#include "util/threadlocks.h"
+
+MVS_NAMESPACE_BEGIN
+
+struct ImagePyramidLevel {
+    mve::ImageBase::ConstPtr image;
+
+    int width, height;
+    math::Matrix3f proj;
+    math::Matrix3f invproj;
+
+    ImagePyramidLevel();
+    ImagePyramidLevel(mve::CameraInfo const& _cam, int width, int height);
+};
+
+inline
+ImagePyramidLevel::ImagePyramidLevel()
+    : width(0)
+    , height(0)
+{
+}
+
+inline
+ImagePyramidLevel::ImagePyramidLevel(mve::CameraInfo const& cam,
+                                 int _width, int _height)
+    : width(_width)
+    , height(_height)
+{
+    cam.fill_calibration(*proj, width, height);
+    cam.fill_inverse_calibration(*invproj, width, height);
+}
+
+/**
+  * Image pyramids are represented as vectors of pyramid levels,
+  * where the presence of an image in a specific level indicates
+  * that all levels with higher indices also contain images.
+  */
+class ImagePyramid : public std::vector<ImagePyramidLevel> {
+public:
+    typedef util::RefPtr<ImagePyramid> Ptr;
+    typedef util::RefPtr<ImagePyramid const> ConstPtr;
+};
+
+class ImagePyramidCache {
+public:
+    static ImagePyramid::ConstPtr get(mve::Scene::Ptr scene,
+                                    mve::View::Ptr view,
+                                    std::string embeddingName,
+                                    int minLevel);
+    static void cleanup();
+
+private:
+    static util::Mutex metadataMutex;
+    static mve::Scene::Ptr cachedScene;
+    static std::string cachedEmbedding;
+
+    static std::map<int, ImagePyramid::Ptr> entries;
+};
+
+MVS_NAMESPACE_END
+
+#endif

--- a/libs/dmrecon/SingleView.h
+++ b/libs/dmrecon/SingleView.h
@@ -12,6 +12,7 @@
 #include "mve/bundlefile.h"
 #include "mve/image.h"
 #include "dmrecon/defines.h"
+#include "dmrecon/ImagePyramid.h"
 
 MVS_NAMESPACE_BEGIN
 
@@ -20,14 +21,14 @@ class SingleView
 public:
     typedef util::RefPtr<SingleView> Ptr;
 
-    SingleView(mve::View::Ptr _view);
+    SingleView(mve::Scene::Ptr _scene, mve::View::Ptr _view);
+    ~SingleView();
 
     void addFeature(std::size_t idx);
     std::vector<std::size_t> const& getFeatureIndices() const;
-    int getMaxLevel() const;
-    mve::ImageBase::Ptr getColorImg() const;
-    mve::ImageBase::Ptr getScaledImg() const;
-    mve::ImageBase::Ptr getPyramidImg(int level) const;
+    int clampLevel(int level) const;
+    mve::ImageBase::ConstPtr const& getScaledImg() const;
+    mve::ImageBase::ConstPtr const& getPyramidImg(int level) const;
     mve::View::Ptr getMVEView() const;
 
     std::string createFileName(float scale) const;
@@ -36,7 +37,7 @@ public:
     math::Vec3f viewRay(int x, int y, int level) const;
     math::Vec3f viewRay(float x, float y, int level) const;
     math::Vec3f viewRayScaled(int x, int y) const;
-    void loadColorImage(std::string const& name);
+    void loadColorImage(std::string const& name, int minLevel);
     bool pointInFrustum(math::Vec3f const& wp);
     void saveReconAsPly(std::string const& path, float scale) const;
     bool seesFeature(std::size_t idx) const;
@@ -60,25 +61,18 @@ private:
     /** feature indices */
     std::vector<std::size_t> featInd;
 
+    /** mve scene */
+    mve::Scene::Ptr scene;
+
     /** mve view */
     mve::View::Ptr view;
 
-    /** dimensions of original image for frustum check */
-    int width;
-    int height;
-
-    mve::ImageBase::Ptr scaled_image;
-    math::Matrix3f proj_scaled;
-    math::Matrix3f invproj_scaled;
-
-    struct PyramidLevel {
-        mve::ImageBase::Ptr image;
-        math::Matrix3f proj;
-        math::Matrix3f invproj;
-    };
+    bool has_target_level;
 
     /** the original image in different scales */
-    std::vector< PyramidLevel > img_pyramid;
+    ImagePyramid::ConstPtr img_pyramid;
+    ImagePyramidLevel source_level, target_level;
+    int minLevel;
 };
 
 
@@ -95,15 +89,16 @@ SingleView::getFeatureIndices() const
 }
 
 inline int
-SingleView::getMaxLevel() const
+SingleView::clampLevel(int level) const
 {
-    return (this->img_pyramid.size() - 1);
-}
+    if (level < minLevel)
+        return minLevel;
 
-inline mve::ImageBase::Ptr
-SingleView::getColorImg() const
-{
-    return this->img_pyramid[0].image;
+    int maxLevel = this->img_pyramid->size() - 1;
+    if (level > maxLevel)
+        return maxLevel;
+
+    return level;
 }
 
 inline mve::View::Ptr
@@ -112,20 +107,18 @@ SingleView::getMVEView() const
     return this->view;
 }
 
-inline mve::ImageBase::Ptr
+inline mve::ImageBase::ConstPtr const&
 SingleView::getPyramidImg(int level) const
 {
-    if (level >= int(this->img_pyramid.size())) {
-        throw std::invalid_argument("Requested image does not exist.");
-    }
-    return this->img_pyramid[level].image;
+    assert(this->img_pyramid->at(level).image != NULL);
+    return this->img_pyramid->at(level).image;
 }
 
-inline mve::ImageBase::Ptr
+inline mve::ImageBase::ConstPtr const&
 SingleView::getScaledImg() const
 {
-    assert(this->scaled_image != NULL);
-    return this->scaled_image;
+    assert(this->has_target_level);
+    return this->target_level.image;
 }
 
 inline std::string
@@ -141,14 +134,14 @@ SingleView::createFileName(float scale) const
 inline float
 SingleView::footPrint(math::Vec3f const& point)
 {
-    return (this->worldToCam.mult(point, 1)[2] * this->img_pyramid[0].invproj[0]);
+    return (this->worldToCam.mult(point, 1)[2] * this->source_level.invproj[0]);
 }
 
 inline float
 SingleView::footPrintScaled(math::Vec3f const& point)
 {
-    assert(this->scaled_image != NULL);
-    return (this->worldToCam.mult(point, 1)[2] * this->invproj_scaled[0]);
+    assert(this->has_target_level);
+    return (this->worldToCam.mult(point, 1)[2] * this->target_level.invproj[0]);
 }
 
 inline bool
@@ -163,10 +156,10 @@ SingleView::seesFeature(std::size_t idx) const
 inline math::Vec2f
 SingleView::worldToScreenScaled(math::Vec3f const& point)
 {
-    assert(this->scaled_image != NULL);
+    assert(this->has_target_level);
 
     math::Vec3f cp(this->worldToCam.mult(point,1.f));
-    math::Vec3f sp = this->proj_scaled * cp;
+    math::Vec3f sp = this->target_level.proj * cp;
 
     math::Vec2f res(sp[0] / sp[2] - 0.5f, sp[1] / sp[2] - 0.5f);
     return res;
@@ -175,11 +168,8 @@ SingleView::worldToScreenScaled(math::Vec3f const& point)
 inline math::Vec2f
 SingleView::worldToScreen(math::Vec3f const& point, int level)
 {
-    if (level != 0 && level >= int(this->img_pyramid.size()))
-        throw std::invalid_argument("Requested pyramid level does not exist.");
-
     math::Vec3f cp(this->worldToCam.mult(point,1.f));
-    math::Vec3f sp = this->img_pyramid[level].proj * cp;
+    math::Vec3f sp = this->img_pyramid->at(level).proj * cp;
 
     math::Vec2f res(sp[0] / sp[2] - 0.5f, sp[1] / sp[2] - 0.5f);
     return res;

--- a/libs/dmrecon/mvstools.cpp
+++ b/libs/dmrecon/mvstools.cpp
@@ -86,17 +86,17 @@ namespace
 }
 
 void
-colAndExactDeriv(mve::ImageBase::Ptr img, PixelCoords const& imgPos,
+colAndExactDeriv(mve::ImageBase const& img, PixelCoords const& imgPos,
     PixelCoords const& gradDir, Samples& color, Samples& deriv)
 {
-    std::size_t width = img->width();
-    std::size_t height = img->height();
-    mve::ImageType type = img->get_type();
+    int width = img.width();
+    int height = img.height();
+    mve::ImageType type = img.get_type();
 
     for (std::size_t i = 0; i < imgPos.size(); ++i)
     {
-        std::size_t left = floor(imgPos[i][0]);
-        std::size_t top = floor(imgPos[i][1]);
+        int left = floor(imgPos[i][0]);
+        int top = floor(imgPos[i][1]);
         assert(left < width-1 && top < height-1);
 
         float x = imgPos[i][0] - left;
@@ -111,24 +111,24 @@ colAndExactDeriv(mve::ImageBase::Ptr img, PixelCoords const& imgPos,
         switch (type) {
         case mve::IMAGE_TYPE_UINT8:
         {
-            mve::ByteImage::Ptr bimg(img);
-            x0 = (1.f-x) * srgb2lin[bimg->at(p0  )] + x * srgb2lin[bimg->at(p0+3)];
-            x1 = (1.f-x) * srgb2lin[bimg->at(p0+1)] + x * srgb2lin[bimg->at(p0+4)];
-            x2 = (1.f-x) * srgb2lin[bimg->at(p0+2)] + x * srgb2lin[bimg->at(p0+5)];
-            x3 = (1.f-x) * srgb2lin[bimg->at(p1  )] + x * srgb2lin[bimg->at(p1+3)];
-            x4 = (1.f-x) * srgb2lin[bimg->at(p1+1)] + x * srgb2lin[bimg->at(p1+4)];
-            x5 = (1.f-x) * srgb2lin[bimg->at(p1+2)] + x * srgb2lin[bimg->at(p1+5)];
+            mve::ByteImage const& bimg = dynamic_cast<mve::ByteImage const&>(img);
+            x0 = (1.f-x) * srgb2lin[bimg.at(p0  )] + x * srgb2lin[bimg.at(p0+3)];
+            x1 = (1.f-x) * srgb2lin[bimg.at(p0+1)] + x * srgb2lin[bimg.at(p0+4)];
+            x2 = (1.f-x) * srgb2lin[bimg.at(p0+2)] + x * srgb2lin[bimg.at(p0+5)];
+            x3 = (1.f-x) * srgb2lin[bimg.at(p1  )] + x * srgb2lin[bimg.at(p1+3)];
+            x4 = (1.f-x) * srgb2lin[bimg.at(p1+1)] + x * srgb2lin[bimg.at(p1+4)];
+            x5 = (1.f-x) * srgb2lin[bimg.at(p1+2)] + x * srgb2lin[bimg.at(p1+5)];
             break;
         }
         case mve::IMAGE_TYPE_FLOAT:
         {
-            mve::FloatImage::Ptr fimg(img);
-            x0 = (1.f-x) * fimg->at(p0  ) + x * fimg->at(p0+3);
-            x1 = (1.f-x) * fimg->at(p0+1) + x * fimg->at(p0+4);
-            x2 = (1.f-x) * fimg->at(p0+2) + x * fimg->at(p0+5);
-            x3 = (1.f-x) * fimg->at(p1  ) + x * fimg->at(p1+3);
-            x4 = (1.f-x) * fimg->at(p1+1) + x * fimg->at(p1+4);
-            x5 = (1.f-x) * fimg->at(p1+2) + x * fimg->at(p1+5);
+            mve::FloatImage const& fimg = dynamic_cast<mve::FloatImage const&>(img);
+            x0 = (1.f-x) * fimg.at(p0  ) + x * fimg.at(p0+3);
+            x1 = (1.f-x) * fimg.at(p0+1) + x * fimg.at(p0+4);
+            x2 = (1.f-x) * fimg.at(p0+2) + x * fimg.at(p0+5);
+            x3 = (1.f-x) * fimg.at(p1  ) + x * fimg.at(p1+3);
+            x4 = (1.f-x) * fimg.at(p1+1) + x * fimg.at(p1+4);
+            x5 = (1.f-x) * fimg.at(p1+2) + x * fimg.at(p1+5);
             break;
         }
         default:
@@ -144,27 +144,27 @@ colAndExactDeriv(mve::ImageBase::Ptr img, PixelCoords const& imgPos,
         switch (type) {
         case mve::IMAGE_TYPE_UINT8:
         {
-            mve::ByteImage::Ptr bimg(img);
+            mve::ByteImage const& bimg = dynamic_cast<mve::ByteImage const&>(img);
             for (std::size_t c = 0; c < 3; ++c) {
                 deriv[i][c] =
-                    u * (srgb2lin[bimg->at(p0+3)] - srgb2lin[bimg->at(p0)])
-                    + v * (srgb2lin[bimg->at(p1)] - srgb2lin[bimg->at(p0)])
+                    u * (srgb2lin[bimg.at(p0+3)] - srgb2lin[bimg.at(p0)])
+                    + v * (srgb2lin[bimg.at(p1)] - srgb2lin[bimg.at(p0)])
                     + (v * x + u * y) *
-                        (srgb2lin[bimg->at(p0)] - srgb2lin[bimg->at(p0+3)]
-                         - srgb2lin[bimg->at(p1)] + srgb2lin[bimg->at(p1+3)]);
+                        (srgb2lin[bimg.at(p0)] - srgb2lin[bimg.at(p0+3)]
+                         - srgb2lin[bimg.at(p1)] + srgb2lin[bimg.at(p1+3)]);
                 ++p0; ++p1;
             }
             break;
         }
         case mve::IMAGE_TYPE_FLOAT:
         {
-            mve::FloatImage::Ptr fimg(img);
+            mve::FloatImage const& fimg = dynamic_cast<mve::FloatImage const&>(img);
             for (std::size_t c = 0; c < 3; ++c) {
                 deriv[i][c] =
-                    u * (fimg->at(p0+3) - fimg->at(p0))
-                    + v * (fimg->at(p1) - fimg->at(p0))
-                    + (v * x + u * y) * (fimg->at(p0) - fimg->at(p0+3)
-                        - fimg->at(p1) + fimg->at(p1+3));
+                    u * (fimg.at(p0+3) - fimg.at(p0))
+                    + v * (fimg.at(p1) - fimg.at(p0))
+                    + (v * x + u * y) * (fimg.at(p0) - fimg.at(p0+3)
+                        - fimg.at(p1) + fimg.at(p1+3));
                 ++p0; ++p1;
             }
             break;
@@ -176,34 +176,34 @@ colAndExactDeriv(mve::ImageBase::Ptr img, PixelCoords const& imgPos,
 
 /* ------------------------------------------------------------------ */
 
-void getXYZColorAtPix(mve::ImageBase::Ptr img,
+void getXYZColorAtPix(mve::ImageBase const& img,
     std::vector<math::Vec2i> const& imgPos, Samples* color)
 {
-    std::size_t width = img->width();
-    mve::ImageType type = img->get_type();
+    int width = img.width();
+    mve::ImageType type = img.get_type();
     Samples::iterator itCol = color->begin();
 
     switch (type) {
     case mve::IMAGE_TYPE_UINT8:
     {
-        mve::ByteImage::Ptr bimg(img);
+        mve::ByteImage const& bimg = dynamic_cast<mve::ByteImage const&>(img);
         for (std::size_t i = 0; i < imgPos.size(); ++i) {
             std::size_t idx = imgPos[i][1] * width + imgPos[i][0];
-            (*itCol)[0] = srgb2lin[bimg->at(idx,0)];
-            (*itCol)[1] = srgb2lin[bimg->at(idx,1)];
-            (*itCol)[2] = srgb2lin[bimg->at(idx,2)];
+            (*itCol)[0] = srgb2lin[bimg.at(idx,0)];
+            (*itCol)[1] = srgb2lin[bimg.at(idx,1)];
+            (*itCol)[2] = srgb2lin[bimg.at(idx,2)];
             ++itCol;
         }
         break;
     }
     case mve::IMAGE_TYPE_FLOAT:
     {
-        mve::FloatImage::Ptr fimg(img);
+        mve::FloatImage const& fimg = dynamic_cast<mve::FloatImage const&>(img);
         for (std::size_t i = 0; i < imgPos.size(); ++i) {
             std::size_t idx = imgPos[i][1] * width + imgPos[i][0];
-            (*itCol)[0] = fimg->at(idx,0);
-            (*itCol)[1] = fimg->at(idx,1);
-            (*itCol)[2] = fimg->at(idx,2);
+            (*itCol)[0] = fimg.at(idx,0);
+            (*itCol)[1] = fimg.at(idx,1);
+            (*itCol)[2] = fimg.at(idx,2);
             ++itCol;
         }
         break;
@@ -216,18 +216,18 @@ void getXYZColorAtPix(mve::ImageBase::Ptr img,
 /* ------------------------------------------------------------------ */
 
 void
-getXYZColorAtPos(mve::ImageBase::Ptr img, PixelCoords const& imgPos,
+getXYZColorAtPos(mve::ImageBase const& img, PixelCoords const& imgPos,
     Samples* color)
 {
-    std::size_t width = img->width();
-    std::size_t height = img->height();
-    mve::ImageType type = img->get_type();
+    int width = img.width();
+    int height = img.height();
+    mve::ImageType type = img.get_type();
     PixelCoords::const_iterator citPos;
     Samples::iterator itCol = color->begin();
 
     for (citPos = imgPos.begin(); citPos != imgPos.end(); ++citPos, ++itCol) {
-        size_t i = floor((*citPos)[0]);
-        size_t j = floor((*citPos)[1]);
+        int i = floor((*citPos)[0]);
+        int j = floor((*citPos)[1]);
         assert(i < width-1 && j < height-1);
 
         float u = (*citPos)[0] - i;
@@ -238,24 +238,24 @@ getXYZColorAtPos(mve::ImageBase::Ptr img, PixelCoords const& imgPos,
         switch (type) {
         case mve::IMAGE_TYPE_UINT8:
         {
-            mve::ByteImage::Ptr bimg(img);
-            x0 = (1.f-u) * srgb2lin[bimg->at(p0  )] + u * srgb2lin[bimg->at(p0+3)];
-            x1 = (1.f-u) * srgb2lin[bimg->at(p0+1)] + u * srgb2lin[bimg->at(p0+4)];
-            x2 = (1.f-u) * srgb2lin[bimg->at(p0+2)] + u * srgb2lin[bimg->at(p0+5)];
-            x3 = (1.f-u) * srgb2lin[bimg->at(p1  )] + u * srgb2lin[bimg->at(p1+3)];
-            x4 = (1.f-u) * srgb2lin[bimg->at(p1+1)] + u * srgb2lin[bimg->at(p1+4)];
-            x5 = (1.f-u) * srgb2lin[bimg->at(p1+2)] + u * srgb2lin[bimg->at(p1+5)];
+            mve::ByteImage const& bimg = dynamic_cast<mve::ByteImage const&>(img);
+            x0 = (1.f-u) * srgb2lin[bimg.at(p0  )] + u * srgb2lin[bimg.at(p0+3)];
+            x1 = (1.f-u) * srgb2lin[bimg.at(p0+1)] + u * srgb2lin[bimg.at(p0+4)];
+            x2 = (1.f-u) * srgb2lin[bimg.at(p0+2)] + u * srgb2lin[bimg.at(p0+5)];
+            x3 = (1.f-u) * srgb2lin[bimg.at(p1  )] + u * srgb2lin[bimg.at(p1+3)];
+            x4 = (1.f-u) * srgb2lin[bimg.at(p1+1)] + u * srgb2lin[bimg.at(p1+4)];
+            x5 = (1.f-u) * srgb2lin[bimg.at(p1+2)] + u * srgb2lin[bimg.at(p1+5)];
             break;
         }
         case mve::IMAGE_TYPE_FLOAT:
         {
-            mve::FloatImage::Ptr fimg(img);
-            x0 = (1.f-u) * fimg->at(p0  ) + u * fimg->at(p0+3);
-            x1 = (1.f-u) * fimg->at(p0+1) + u * fimg->at(p0+4);
-            x2 = (1.f-u) * fimg->at(p0+2) + u * fimg->at(p0+5);
-            x3 = (1.f-u) * fimg->at(p1  ) + u * fimg->at(p1+3);
-            x4 = (1.f-u) * fimg->at(p1+1) + u * fimg->at(p1+4);
-            x5 = (1.f-u) * fimg->at(p1+2) + u * fimg->at(p1+5);
+            mve::FloatImage const& fimg = dynamic_cast<mve::FloatImage const&>(img);
+            x0 = (1.f-u) * fimg.at(p0  ) + u * fimg.at(p0+3);
+            x1 = (1.f-u) * fimg.at(p0+1) + u * fimg.at(p0+4);
+            x2 = (1.f-u) * fimg.at(p0+2) + u * fimg.at(p0+5);
+            x3 = (1.f-u) * fimg.at(p1  ) + u * fimg.at(p1+3);
+            x4 = (1.f-u) * fimg.at(p1+1) + u * fimg.at(p1+4);
+            x5 = (1.f-u) * fimg.at(p1+2) + u * fimg.at(p1+5);
             break;
         }
         default:

--- a/libs/dmrecon/mvstools.h
+++ b/libs/dmrecon/mvstools.h
@@ -13,16 +13,16 @@
 MVS_NAMESPACE_BEGIN
 
 /** interpolate color and derivative at given sample positions */
-void colAndExactDeriv(mve::ImageBase::Ptr img,
+void colAndExactDeriv(mve::ImageBase const& img,
     PixelCoords const& imgPos, PixelCoords const& gradDir,
     Samples& color, Samples& deriv);
 
 /** get color at given pixel positions (no interpolation) */
-void getXYZColorAtPix(mve::ImageBase::Ptr img,
+void getXYZColorAtPix(mve::ImageBase const& img,
     std::vector<math::Vec2i> const& imgPos, Samples* color);
 
 /** interpolate only color at given sample positions */
-void getXYZColorAtPos(mve::ImageBase::Ptr img,
+void getXYZColorAtPos(mve::ImageBase const& img,
     PixelCoords const& imgPos, Samples* color);
 
 /** Computes the parallax between two views with respect to some 3D point p */


### PR DESCRIPTION
In this implementation, the image pyramid cache doesn't yet support multiple scenes, but SingleView gracefully degrades to its previous behavior of constructing its own pyramid.
