### PR TITLE
MVE: fix a bug in mve::image::crop (wrong handling of protrait images)

### DIFF
--- a/libs/mve/_gtest_imagetools.cc
+++ b/libs/mve/_gtest_imagetools.cc
@@ -187,6 +187,17 @@ TEST(ImageToolsTest, ImageCropOutside2)
             EXPECT_EQ(127, img->at(i));
 }
 
+TEST(ImageToolsTest, CropImagePortrait)
+{
+    mve::ByteImage::Ptr img = mve::ByteImage::create(1, 2, 1);
+    unsigned char white = 255;
+    unsigned char black = 0;
+    img->at(0, 0, 0) = black;
+    img->at(0, 1, 0) = white;
+    mve::ByteImage::Ptr cropped = mve::image::crop(img, 1, 1, 0, 1, &black);
+    EXPECT_EQ(white, cropped->at(0));
+}
+
 TEST(ImageToolsTest, CropImageOverlap1)
 {
     mve::ByteImage::Ptr img = mve::ByteImage::create(4, 4, 2);

--- a/libs/mve/imagetools.h
+++ b/libs/mve/imagetools.h
@@ -987,7 +987,7 @@ crop (typename Image<T>::ConstPtr image, int width, int height,
     for (int y = std::max(0, -top); y < std::min(height, ih - top); ++y)
     {
         int lookup_y = top + y;
-        if (lookup_y >= iw)
+        if (lookup_y >= ih)
             break;
         T* out_ptr = &out->at(left < 0 ? -left : 0, y, 0);
         T const* in_ptr = &image->at(left > 0 ? left : 0, lookup_y, 0);


### PR DESCRIPTION
Fixes a bug which occurs if you crop a portrait image to a region which has a higher y coordinates than the image width.
