### PR TITLE
MAKESCENE: fix case for original image missing

### DIFF
--- a/apps/makescene/makescene.cc
+++ b/apps/makescene/makescene.cc
@@ -839,7 +839,7 @@ import_bundle (AppSettings const& conf)
 
         if (original.get())
             view->add_image("original", original);
-        else if (conf.import_orig && undist.get())
+        else if (conf.import_orig && !original.get())
             std::cerr << "Warning: Original image missing!" << std::endl;
 
         /* Add EXIF data to view if available. */


### PR DESCRIPTION
Checking for a NULL original image seems more reasonable here.
