### PR TITLE
bundlefile.cc: increased the maximum number of a feature's camera refere...

### DIFF
--- a/libs/mve/bundle_file.cc
+++ b/libs/mve/bundle_file.cc
@@ -159,7 +159,7 @@ BundleFile::read_bundle_intern (std::string const& filename)
         /* Read feature references. */
         int ref_amount;
         in >> ref_amount;
-        if (ref_amount < 0 || ref_amount > 100)
+        if (ref_amount < 0 || ref_amount > num_cameras)
         {
             in.close();
             throw util::Exception("Invalid feature reference amount");


### PR DESCRIPTION
...nces to the total number of cameras

Hi Simon,

Daniel und ich haben die Citywall mal angepasst, dass nur noch das fragliche Feature und die von ihm referenzierten Cams enthalten sind. Oeffne in UMVE mal /gris/bigds/home/miwaecht/datasets/bundle-test und lade dazu noch das low-res-mesh-for-orientation.ply. Das Feature ist ganz leicht rechts vom Brunnen und die fraglichen Views gucken tatsaechlich alle grob in die Richtung. Wir koennen nicht zweifelsfrei sagen, ob das richtig ist. Aber zumindest ist es nicht offensichtlich Schwachsinn.

Hab das Maximum mal auf num_cameras erhoeht. Das ist zwar viel zu grob abgeschaetzt, dann hat der Code aber keine magic number mehr drin.

Michi
