### PR TITLE
UMVE: support loading tabs from plugins

### DIFF
--- a/apps/umve/mainwindowtab.h
+++ b/apps/umve/mainwindowtab.h
@@ -17,6 +17,10 @@ public:
     MainWindowTab (QWidget* parent);
     virtual ~MainWindowTab (void);
 
+    /* title of this tab when added to a QTabWidget */
+    virtual QString get_title (void) = 0;
+
+    /* should be called when the parent QTabWidget switches to this tab */
     void set_tab_active (bool tab_active);
 };
 

--- a/apps/umve/scene_inspect/scene_inspect.cc
+++ b/apps/umve/scene_inspect/scene_inspect.cc
@@ -178,3 +178,11 @@ SceneInspect::on_save_screenshot (void)
         QMessageBox::critical(this, "Cannot save image",
             "Error saving image");
 }
+
+/* ---------------------------------------------------------------- */
+
+QString
+SceneInspect::get_title (void)
+{
+    return tr("Scene inspect");
+}

--- a/apps/umve/scene_inspect/scene_inspect.h
+++ b/apps/umve/scene_inspect/scene_inspect.h
@@ -31,6 +31,8 @@ public:
     /* Removes references to the scene. */
     void reset (void);
 
+    virtual QString get_title (void);
+
 private:
     void create_actions (QToolBar* toolbar);
 

--- a/apps/umve/viewinspect/viewinspect.cc
+++ b/apps/umve/viewinspect/viewinspect.cc
@@ -814,3 +814,11 @@ ViewInspect::reset (void)
     this->scroll_image->get_image()->setPixmap(QPixmap());
     this->embeddings->clear();
 }
+
+/* ---------------------------------------------------------------- */
+
+QString
+ViewInspect::get_title (void)
+{
+    return tr("View inspect");
+}

--- a/apps/umve/viewinspect/viewinspect.h
+++ b/apps/umve/viewinspect/viewinspect.h
@@ -90,8 +90,8 @@ public:
     void load_image_file (QString filename);
     void load_mve_file (QString filename);
     void load_ply_file (QString filename);
-
     void reset (void);
+    virtual QString get_title (void);
 };
 
 #endif /* VIEW_INSPECT_HEADER */


### PR DESCRIPTION
Some small changes to enable implementing `MainWindowTab`s not only in the main UMVE codebase, but also in separate plugins.
