### PR TITLE
Makefile: Enable -fno-math-errno

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,6 +1,6 @@
 # Default values.
 CXX ?= g++
-CXXFLAGS ?= -Wall -Wextra -Wundef -pedantic -g -O3
+CXXFLAGS ?= -Wall -Wextra -Wundef -pedantic -g -O3 -fno-math-errno
 
 # Delete this if libgomp.a is not installed! (e.g., OS X without gcc)
 OPENMP ?= -fopenmp


### PR DESCRIPTION
This option is deemed unsafe by gcc, because it changes the semantics of the
stdlib math functions. We do not check errno after calling, e.g., std::sqrt,
so we can skip setting it. Allowing std::sqrt to be inlined as a single
instruction, this makes more loops vectorizable.
