### PR TITLE
UMVE: Rename QFileSelector to FileSelector

### DIFF
--- a/apps/umve/guihelpers.cc
+++ b/apps/umve/guihelpers.cc
@@ -218,7 +218,7 @@ QCollapsible::set_content_indent(int pixels)
 /* ---------------------------------------------------------------- */
 /* ---------------------------------------------------------------- */
 
-QFileSelector::QFileSelector (QWidget* parent)
+FileSelector::FileSelector (QWidget* parent)
     : QPushButton(parent)
 {
     this->dironly = false;
@@ -231,25 +231,25 @@ QFileSelector::QFileSelector (QWidget* parent)
 }
 
 void
-QFileSelector::set_directory_mode (void)
+FileSelector::set_directory_mode (void)
 {
     this->dironly = true;
 }
 
 void
-QFileSelector::set_ellipsize (std::size_t chars)
+FileSelector::set_ellipsize (std::size_t chars)
 {
     this->ellipsize = chars;
 }
 
 std::string const&
-QFileSelector::get_filename (void) const
+FileSelector::get_filename (void) const
 {
     return this->filename;
 }
 
 void
-QFileSelector::on_clicked (void)
+FileSelector::on_clicked (void)
 {
     QString filename;
     if (this->dironly)

--- a/apps/umve/guihelpers.h
+++ b/apps/umve/guihelpers.h
@@ -66,7 +66,7 @@ public:
 /* ---------------------------------------------------------------- */
 
 /** File or directory selector button. */
-class QFileSelector : public QPushButton
+class FileSelector : public QPushButton
 {
     Q_OBJECT
 
@@ -79,7 +79,7 @@ private slots:
     void on_clicked (void);
 
 public:
-    QFileSelector (QWidget* parent = NULL);
+    FileSelector (QWidget* parent = NULL);
     void set_directory_mode (void);
     void set_ellipsize (std::size_t chars);
     std::string const& get_filename (void) const;

--- a/apps/umve/scene_addins/addin_offscreen_renderer.cc
+++ b/apps/umve/scene_addins/addin_offscreen_renderer.cc
@@ -12,12 +12,12 @@
 
 AddinOffscreenRenderer::AddinOffscreenRenderer (void)
 {
-    this->output_frame_dir = new QFileSelector();
+    this->output_frame_dir = new FileSelector();
     this->output_frame_dir->set_ellipsize(20);
     this->output_frame_dir->set_directory_mode();
     this->output_frame_dir->setToolTip("Set output frame directory");
 
-    this->sequence_file = new QFileSelector();
+    this->sequence_file = new FileSelector();
     this->sequence_file->set_ellipsize(20);
     this->sequence_file->setToolTip("Set input sequence file");
 

--- a/apps/umve/scene_addins/addin_offscreen_renderer.h
+++ b/apps/umve/scene_addins/addin_offscreen_renderer.h
@@ -32,8 +32,8 @@ private:
 private:
     ogl::Camera* camera;
     QVBoxLayout* main_box;
-    QFileSelector* sequence_file;
-    QFileSelector* output_frame_dir;
+    FileSelector* sequence_file;
+    FileSelector* output_frame_dir;
     QPushButton* play_but;
     QSpinBox* width_spin;
     QSpinBox* height_spin;


### PR DESCRIPTION
Rename UMVE's QFileSelector because a class with the same name was introduced in Qt 5.2.
