### PR TITLE
Makefile: enable -funsafe-math-optimizations

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,6 +1,6 @@
 # Default values.
 CXX ?= g++
-CXXFLAGS ?= -Wall -Wextra -Wundef -pedantic -g -O3
+CXXFLAGS ?= -Wall -Wextra -Wundef -pedantic -g -O3 -funsafe-math-optimizations
 
 # Delete this if libgomp.a is not installed! (e.g., OS X without gcc)
 OPENMP ?= -fopenmp


### PR DESCRIPTION
This option allows the compiler to auto-vectorize reduction loops. Despite the
name, it should be safe for our code as it doesn't enable the slightly risky
-ffinite-math-only like -ffast-math does.
