### PR TITLE
UMVE: Trigger a repaint only if all window system events have been processed.

### DIFF
--- a/apps/umve/glwidget.cc
+++ b/apps/umve/glwidget.cc
@@ -18,6 +18,12 @@ GLWidget::GLWidget (QWidget *parent)
 {
     this->setFocusPolicy(Qt::ClickFocus);
     this->makeCurrent();
+
+    /* This timer triggers a repaint after all events in the window system's
+     * event queue have been processed. Thus a snappy 3D view is provided. */
+    this->repaint_timer = new QTimer(this);
+    this->repaint_timer->setSingleShot(true);
+    connect (this->repaint_timer, SIGNAL (timeout()), this, SLOT (repaint()));
 }
 
 /* ---------------------------------------------------------------- */
@@ -102,7 +108,7 @@ GLWidget::mousePressEvent (QMouseEvent *event)
     e.y = event->y();
 #endif
     this->context->mouse_event(e);
-    this->repaint();
+    this->repaint_async();
 }
 
 /* ---------------------------------------------------------------- */
@@ -123,7 +129,7 @@ GLWidget::mouseReleaseEvent (QMouseEvent *event)
     e.y = event->y();
 #endif
     this->context->mouse_event(e);
-    this->repaint();
+    this->repaint_async();
 }
 
 /* ---------------------------------------------------------------- */
@@ -144,7 +150,7 @@ GLWidget::mouseMoveEvent (QMouseEvent *event)
     e.y = event->y();
 #endif
     this->context->mouse_event(e);
-    this->repaint();
+    this->repaint_async();
 }
 
 /* ---------------------------------------------------------------- */
@@ -168,7 +174,7 @@ GLWidget::wheelEvent (QWheelEvent* event)
     e.y = event->y();
 #endif
     this->context->mouse_event(e);
-    this->repaint();
+    this->repaint_async();
 }
 
 /* ---------------------------------------------------------------- */
@@ -186,7 +192,7 @@ GLWidget::keyPressEvent (QKeyEvent* event)
     e.type = ogl::KEYBOARD_EVENT_PRESS;
     e.keycode = event->key();
     this->context->keyboard_event(e);
-    this->repaint();
+    this->repaint_async();
 }
 
 /* ---------------------------------------------------------------- */
@@ -204,5 +210,5 @@ GLWidget::keyReleaseEvent (QKeyEvent* event)
     e.type = ogl::KEYBOARD_EVENT_RELEASE;
     e.keycode = event->key();
     this->context->keyboard_event(e);
-    this->repaint();
+    this->repaint_async();
 }

--- a/apps/umve/glwidget.h
+++ b/apps/umve/glwidget.h
@@ -4,6 +4,7 @@
 #include <set>
 #include <QGLWidget>
 #include <QMouseEvent>
+#include <QTimer>
 
 #include "ogl/context.h"
 
@@ -22,6 +23,7 @@ public:
 
 public slots:
     void repaint_gl (void);
+    void repaint_async (void);
     void gl_context (void);
 
 public:
@@ -46,6 +48,7 @@ private:
     int gl_height;
     bool cx_init;
     std::set<ogl::Context*> init_set;
+    QTimer* repaint_timer;
 };
 
 /* ---------------------------------------------------------------- */
@@ -67,6 +70,18 @@ GLWidget::repaint_gl (void)
 {
     this->updateGL();
     //this->repaint();
+}
+
+inline void
+GLWidget::repaint_async (void)
+{
+    /* Don't issue an immediate repaint but let the timer trigger
+     * a repaint after all events have been processed. */
+
+    if (this->repaint_timer->isActive())
+        return;
+
+    this->repaint_timer->start();
 }
 
 inline void


### PR DESCRIPTION
This fixes performance problems under recent Qt5-Linux-combinations (for example Ubuntu 14.10). By using a QTimer with a timeout of 0 in single shot mode, all mouse and keyboard events are processed before repaint() is called. [http://qt-project.org/doc/qt-4.8/qtimer.html#details] Thus the scene inspect is interactive again. The window resizing is still a bit sluggish.