### PR TITLE
SFM: add minimal number of valid cameras to track triangulation

### DIFF
--- a/apps/sfmrecon/sfmrecon.cc
+++ b/apps/sfmrecon/sfmrecon.cc
@@ -264,7 +264,7 @@ sfm_reconstruct (AppSettings const& conf)
     incremental.initialize(&viewports, &tracks, &cameras);
 
     /* Reconstruct track positions for the intial pair. */
-    incremental.triangulate_new_tracks();
+    incremental.triangulate_new_tracks(2);
     incremental.invalidate_large_error_tracks();
 
     /* Run bundle adjustment. */
@@ -307,7 +307,7 @@ sfm_reconstruct (AppSettings const& conf)
 
         std::cout << "Running single camera bundle adjustment..." << std::endl;
         incremental.bundle_adjustment_single_cam(next_view_id);
-        incremental.triangulate_new_tracks();
+        incremental.triangulate_new_tracks(3);
         incremental.invalidate_large_error_tracks();
         num_cameras_reconstructed += 1;
 

--- a/libs/sfm/bundler_incremental.cc
+++ b/libs/sfm/bundler_incremental.cc
@@ -173,7 +173,7 @@ Incremental::reconstruct_next_view (int view_id)
 /* ---------------------------------------------------------------- */
 
 void
-Incremental::triangulate_new_tracks (void)
+Incremental::triangulate_new_tracks (int min_num_views)
 {
     Triangulate::Options triangulate_opts;
     triangulate_opts.error_threshold = this->opts.new_track_error_threshold;
@@ -208,7 +208,7 @@ Incremental::triangulate_new_tracks (void)
         }
 
         /* Skip tracks with too few valid cameras. */
-        if (poses.size() < 2)
+        if ((int)poses.size() < min_num_views)
             continue;
 
         /* Accept track if triangulation was successful. */

--- a/libs/sfm/bundler_incremental.h
+++ b/libs/sfm/bundler_incremental.h
@@ -65,8 +65,8 @@ public:
     void find_next_views (std::vector<int>* next_views);
     /** Incrementally adds the given view to the bundle. */
     bool reconstruct_next_view (int view_id);
-    /** Triangulates tracks without 3D position and at least 2 views. */
-    void triangulate_new_tracks (void);
+    /** Triangulates tracks without 3D position and at least N views. */
+    void triangulate_new_tracks (int min_num_views);
     /** Deletes tracks with a large reprojection error. */
     void invalidate_large_error_tracks (void);
     /** Runs bundle adjustment on both, structure and motion. */


### PR DESCRIPTION
does not actually change current behavior of sfmrecon