### PR TITLE
UMVE: Change MACOSX_DEPLOYMENT_TARGET for qmake

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -11,10 +11,7 @@ CXXFLAGS += -pthread
 
 UNAME = $(shell uname)
 ifeq (${UNAME},Darwin)
-    # Use a recent OS X SDK - homebrew qt5 needs it.
     OPENMP = 
-    CXXFLAGS += -mmacosx-version-min=10.7
-    LDFLAGS += -mmacosx-version-min=10.7
 endif
 
 COMPILE.cc = ${CXX} ${CXXFLAGS} ${CPPFLAGS} -c

--- a/apps/umve/umve.pro
+++ b/apps/umve/umve.pro
@@ -22,7 +22,7 @@ RCC_DIR = build
 
 # Options specific to OS X.
 macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.7
+    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9
     CONFIG -= app_bundle
     QMAKE_LFLAGS += -L/usr/local/lib
     QMAKE_LFLAGS -= -fopenmp


### PR DESCRIPTION
Qmake otherwise compiles and links against old/outdated c++ libs on OSX.
With this change maxosx-version-min is also no longer necessary in the
MVE Makefile.inc.