### PR TITLE
SFM: BA add non-Schur solver for linear step

### DIFF
--- a/libs/sfm/ba_linear_solver.h
+++ b/libs/sfm/ba_linear_solver.h
@@ -50,10 +50,15 @@ public:
         SparseMatrixType const& jac_points,
         DenseVectorType const& values, DenseVectorType* delta_x);
 
-    /* Conjugate Gradient on H = J^T * J. */
-    //Status solve (SparseMatrixType const& jac_cams,
-    //    SparseMatrixType const& jac_points,
-    //    DenseVectorType const& values, DenseVectorType* delta_x);
+    /**
+     * J is the Jacobian of the problem. If H = Jt * J has a block diagonal
+     * structure (e.g. 'motion only' or 'structure only' problems in BA),
+     * block_size can be used to directly invert H. If block_size is 0
+     * the diagonal of H is used as a preconditioner and the linear system
+     * is solved via conjugate gradient.
+     */
+    Status solve (SparseMatrixType const& J, DenseVectorType const& values,
+        DenseVectorType* delta_x, std::size_t block_size = 0);
 
 private:
     Options opts;

--- a/tests/sfm/gtest_ba_conjugate_gradient.cc
+++ b/tests/sfm/gtest_ba_conjugate_gradient.cc
@@ -40,7 +40,7 @@ TEST(ConjugateGradientTest, CGSolverTest)
     triplets.emplace_back(1, 1, 2.0);
     triplets.emplace_back(2, 2, 3.0);
     triplets.emplace_back(3, 3, 4.0);
-    A.set_from_triplets(&triplets);
+    A.set_from_triplets(triplets);
 
     DenseVector b(4);
     b[0] = 1;
@@ -74,7 +74,7 @@ TEST(ConjugateGradientTest, CGSolverExplicitFunctorTest)
     triplets.emplace_back(1, 1, 2.0);
     triplets.emplace_back(2, 2, 3.0);
     triplets.emplace_back(3, 3, 4.0);
-    A.set_from_triplets(&triplets);
+    A.set_from_triplets(triplets);
 
     DenseVector b(4);
     b[0] = 1;
@@ -109,7 +109,7 @@ TEST(ConjugateGradientTest, PreconditionedCGSolverExactTest)
     tripletsA.emplace_back(1, 1, 2.0);
     tripletsA.emplace_back(2, 2, 3.0);
     tripletsA.emplace_back(3, 3, 4.0);
-    A.set_from_triplets(&tripletsA);
+    A.set_from_triplets(tripletsA);
 
     SparseMatrix P(4, 4);
     SparseMatrix::Triplets tripletsP;
@@ -117,7 +117,7 @@ TEST(ConjugateGradientTest, PreconditionedCGSolverExactTest)
     tripletsP.emplace_back(1, 1, 1.0 / 2.0);
     tripletsP.emplace_back(2, 2, 1.0 / 3.0);
     tripletsP.emplace_back(3, 3, 1.0 / 4.0);
-    P.set_from_triplets(&tripletsP);
+    P.set_from_triplets(tripletsP);
 
     DenseVector b(4);
     b[0] = 1;
@@ -152,7 +152,7 @@ TEST(ConjugateGradientTest, PreconditionedCGSolverApproximateTest)
     tripletsA.emplace_back(1, 1, 2.0);
     tripletsA.emplace_back(2, 2, 3.0);
     tripletsA.emplace_back(3, 3, 4.0);
-    A.set_from_triplets(&tripletsA);
+    A.set_from_triplets(tripletsA);
 
     SparseMatrix P(4, 4);
     SparseMatrix::Triplets tripletsP;
@@ -160,7 +160,7 @@ TEST(ConjugateGradientTest, PreconditionedCGSolverApproximateTest)
     tripletsP.emplace_back(1, 1, 1.0 / 1.0);
     tripletsP.emplace_back(2, 2, 1.0 / 2.0);
     tripletsP.emplace_back(3, 3, 1.0 / 3.0);
-    P.set_from_triplets(&tripletsP);
+    P.set_from_triplets(tripletsP);
 
     DenseVector b(4);
     b[0] = 1;


### PR DESCRIPTION
This is useful for 'structure only' or 'motion only' problems
in BA, where the approximate Hessian has a block diagonal
structure and can be inverted directly.