### PR TITLE
SFM: Add transposed_multiply to sparse matrix

### DIFF
--- a/libs/sfm/ba_linear_solver.cc
+++ b/libs/sfm/ba_linear_solver.cc
@@ -87,7 +87,6 @@ LinearSolver::solve_schur (SparseMatrixType const& jac_cams,
     SparseMatrixType const& Jc = jac_cams;
     SparseMatrixType const& Jp = jac_points;
     SparseMatrixType JcT = Jc.transpose();
-    SparseMatrixType JpT = Jp.transpose();
 
     /* Compute the blocks of the Hessian. */
     SparseMatrixType B, C;
@@ -96,8 +95,8 @@ LinearSolver::solve_schur (SparseMatrixType const& jac_cams,
     SparseMatrixType E = JcT.multiply(Jp);
 
     /* Assemble two values vectors. */
-    DenseVectorType v = JcT.multiply(F);
-    DenseVectorType w = JpT.multiply(F);
+    DenseVectorType v = Jc.transposed_multiply(F);
+    DenseVectorType w = Jp.transposed_multiply(F);
     v.negate_self();
     w.negate_self();
 

--- a/libs/sfm/ba_sparse_matrix.h
+++ b/libs/sfm/ba_sparse_matrix.h
@@ -55,6 +55,7 @@ public:
     SparseMatrix subtract (SparseMatrix const& rhs) const;
     SparseMatrix multiply (SparseMatrix const& rhs) const;
     DenseVector<T> multiply (DenseVector<T> const& rhs) const;
+    DenseVector<T> transposed_multiply (DenseVector<T> const& rhs) const;
     SparseMatrix diagonal_matrix (void) const;
 
     std::size_t num_non_zero (void) const;
@@ -310,6 +311,20 @@ SparseMatrix<T>::multiply (DenseVector<T> const& rhs) const
     for (std::size_t i = 0; i < this->cols; ++i)
         for (std::size_t id = this->outer[i]; id < this->outer[i + 1]; ++id)
             ret[this->inner[id]] += this->values[id] * rhs[i];
+    return ret;
+}
+
+template<typename T>
+DenseVector<T>
+SparseMatrix<T>::transposed_multiply (DenseVector<T> const& rhs) const
+{
+    if (rhs.size() != this->rows)
+        throw std::invalid_argument("Incompatible dimensions");
+
+    DenseVector<T> ret(this->cols, T(0));
+    for (std::size_t i = 0; i < this->cols; ++i)
+        for (std::size_t id = this->outer[i]; id < this->outer[i + 1]; ++id)
+            ret[i] += this->values[id] * rhs[this->inner[id]];
     return ret;
 }
 

--- a/tests/sfm/gtest_ba_sparse_matrix.cc
+++ b/tests/sfm/gtest_ba_sparse_matrix.cc
@@ -190,6 +190,32 @@ TEST(BundleAdjustmentVectorMatrixTest, MatrixVectorMultiplyTest)
     EXPECT_EQ(0, ret[2]);
 }
 
+TEST(BundleAdjustmentVectorMatrixTest, MatrixVectorTransposedMultiplyTest)
+{
+    typedef sfm::ba::SparseMatrix<int> SparseMatrix;
+    typedef sfm::ba::DenseVector<int> DenseVector;
+
+    SparseMatrix m1(4, 3);
+    {
+        SparseMatrix::Triplets triplets;
+        triplets.emplace_back(1, 0, 1);
+        triplets.emplace_back(2, 0, 4);
+        triplets.emplace_back(2, 1, 3);
+        triplets.emplace_back(3, 0, 1);
+        m1.set_from_triplets(triplets);
+    }
+
+    DenseVector v1(4, 0);
+    v1[1] = 1;
+    v1[2] = 2;
+
+    DenseVector ret = m1.transposed_multiply(v1);
+    EXPECT_EQ(3, ret.size());
+    EXPECT_EQ(9, ret[0]);
+    EXPECT_EQ(6, ret[1]);
+    EXPECT_EQ(0, ret[2]);
+}
+
 TEST(BundleAdjustmentVectorMatrixTest, MatrixMultiplyDiagonalTest)
 {
     typedef sfm::ba::SparseMatrix<int> SparseMatrix;


### PR DESCRIPTION
Using this we no longer need to compute the transpose of the large point
jacobian during the linear LM step.