### PR TITLE
FSSR: Fix redefinition of default argument

### DIFF
--- a/libs/fssr/basis_function.h
+++ b/libs/fssr/basis_function.h
@@ -133,7 +133,7 @@ fssr_basis (T const& scale, math::Vector<T, 3> const& pos,
 template <typename T>
 T
 fssr_weight (T const& scale, math::Vector<T, 3> const& pos,
-    math::Vector<T, 3>* deriv = nullptr)
+    math::Vector<T, 3>* deriv)
 {
     T const square_radius = pos.square_norm() / MATH_POW2(scale);
     if (square_radius >= T(9))


### PR DESCRIPTION
Fixes `redefinition of default argument`, default arg is already defined in declaration on line 57.

```
In file included from basis_function.cc:16:
../../libs/fssr/basis_function.h:136:25: error: redefinition of default argument
    math::Vector<T, 3>* deriv = nullptr)
                        ^       ~~~~~~~
../../libs/fssr/basis_function.h:58:25: note: previous definition is here
    math::Vector<T, 3>* deriv = nullptr);
                        ^       ~~~~~~~
1 error generated.
make[2]: *** [basis_function.o] Error 1
make[2]: *** Waiting for unfinished jobs....
In file included from iso_octree.cc:22:
../../libs/fssr/basis_function.h:136:25: error: redefinition of default argument
    math::Vector<T, 3>* deriv = nullptr)
                        ^       ~~~~~~~
../../libs/fssr/basis_function.h:58:25: note: previous definition is here
    math::Vector<T, 3>* deriv = nullptr);
                        ^       ~~~~~~~
1 error generated.
make[2]: *** [iso_octree.o] Error 1
make[1]: *** [all] Error 2
make: *** [all] Error 2
```