### PR TITLE
FSSR: Include missing algorithm header

### DIFF
--- a/libs/fssr/hermite.cc
+++ b/libs/fssr/hermite.cc
@@ -7,6 +7,7 @@
  * of the BSD 3-Clause license. See the LICENSE.txt file for details.
  */
 
+#include <algorithm>
 #include <cmath>
 #include <sstream>
 #include <stdexcept>


### PR DESCRIPTION
std::min and std::max are declared in algorithm.