### PR TITLE
Small changes for MinGW compilation

### DIFF
--- a/libs/mve/image_io.cc
+++ b/libs/mve/image_io.cc
@@ -1075,7 +1075,7 @@ namespace
 ImageBase::Ptr
 load_mvei_file (std::string const& filename)
 {
-    std::ifstream in(filename.c_str());
+    std::ifstream in(filename.c_str(), std::ios::binary);
     if (!in.good())
         throw util::FileException(filename, std::strerror(errno));
 
@@ -1098,7 +1098,7 @@ load_mvei_file (std::string const& filename)
 ImageHeaders
 load_mvei_file_headers (std::string const& filename)
 {
-    std::ifstream in(filename.c_str());
+    std::ifstream in(filename.c_str(), std::ios::binary);
     if (!in.good())
         throw util::FileException(filename, std::strerror(errno));
 

--- a/libs/util/aligned_allocator.h
+++ b/libs/util/aligned_allocator.h
@@ -87,7 +87,7 @@ AlignedAllocator<T, alignment>::allocate (size_type n)
       throw std::bad_alloc();
     size_t size = n * sizeof(T);
     pointer p = nullptr;
-#ifdef _MSC_VER
+#ifdef _WIN32
     p = reinterpret_cast<pointer>(::_aligned_malloc(size, alignment));
     if (p == nullptr)
         throw std::bad_alloc();
@@ -102,7 +102,7 @@ template <typename T, size_t alignment>
 inline void
 AlignedAllocator<T, alignment>::deallocate(pointer p, size_type /*n*/)
 {
-#ifdef _MSC_VER
+#ifdef _WIN32
     ::_aligned_free(p);
 #else
     ::free(p);

--- a/libs/util/system.cc
+++ b/libs/util/system.cc
@@ -10,7 +10,7 @@
 #include <iostream>
 #include <cstdlib>
 #include <csignal>
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(_WIN32)
 #   include <execinfo.h> // ::backtrace
 #endif
 
@@ -51,7 +51,7 @@ signal_segfault_handler (int code)
 void
 print_stack_trace (void)
 {
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(_WIN32)
     /* Get stack pointers for all frames on the stack. */
     void *array[32];
     int const size = ::backtrace(array, 32);


### PR DESCRIPTION
- binary mode for MVEI files
- Use aligned_malloc with MinGW
- backtrace not available with MinGW