### PR TITLE
UMVE: Fix memory alignment issue in rephotographer addin

### DIFF
--- a/apps/umve/scene_addins/addin_rephotographer.cc
+++ b/apps/umve/scene_addins/addin_rephotographer.cc
@@ -153,6 +153,8 @@ AddinRephotographer::on_rephoto_view (mve::View::Ptr view)
         GL_RENDERBUFFER, renderbuffer[1]);
     this->repaint();
 
+    glPixelStorei(GL_PACK_ALIGNMENT, 1);
+
     /* Read color image from OpenGL. */
     mve::ByteImage::Ptr image = mve::ByteImage::create(width, height, 3);
     glReadPixels(0, 0, width, height, GL_RGB, GL_UNSIGNED_BYTE, image->begin());


### PR DESCRIPTION
The ```GL_PACK_ALIGNMENT``` defaults to 4 (word-alignment) instead of 1 (byte-alignment). Thus ```glReadPixels``` requires every row of the ```mve::ByteImage``` to be word-aligned. This is not the case if the width is not a multiple of 4. This fixes a segmentation fault in combination with the current NVIDIA OpenGL implementation.