### PR TITLE
Implement feature matching with cascade hashing

### DIFF
--- a/apps/sfmrecon/sfmrecon.cc
+++ b/apps/sfmrecon/sfmrecon.cc
@@ -58,6 +58,7 @@ struct AppSettings
     int initial_pair_1 = -1;
     int initial_pair_2 = -1;
     int min_views_per_track = 3;
+    bool cascade_hashing = false;
 };
 
 void
@@ -111,6 +112,9 @@ features_and_matching (mve::Scene::Ptr scene, AppSettings const& conf,
     matching_opts.ransac_opts.verbose_output = false;
     matching_opts.use_lowres_matching = conf.lowres_matching;
     matching_opts.match_num_previous_frames = conf.video_matching;
+    matching_opts.matcher_type = conf.cascade_hashing
+        ? sfm::bundler::Matching::MATCHER_CASCADE_HASHING
+        : sfm::bundler::Matching::MATCHER_EXHAUSTIVE;
 
     std::cout << "Performing feature matching..." << std::endl;
     {
@@ -491,6 +495,7 @@ main (int argc, char** argv)
     args.add_option('\0', "track-thres-factor", true, "Error threshold factor for tracks [25]");
     args.add_option('\0', "use-2cam-tracks", false, "Triangulate tracks from only two cameras");
     args.add_option('\0', "initial-pair", true, "Manually specify initial pair IDs [-1,-1]");
+    args.add_option('\0', "cascade-hashing", false, "Use cascade hashing for matching [false]");
     args.parse(argc, argv);
 
     /* Setup defaults. */
@@ -549,6 +554,8 @@ main (int argc, char** argv)
             std::cout << "Using initial pair (" << conf.initial_pair_1
                 << "," << conf.initial_pair_2 << ")." << std::endl;
         }
+        else if (i->opt->lopt == "cascade-hashing")
+            conf.cascade_hashing = true;
         else
         {
             std::cerr << "Error: Unexpected option: "

--- a/libs/math/matrix.h
+++ b/libs/math/matrix.h
@@ -53,6 +53,7 @@ template <typename T, int N, int M>
 class Matrix
 {
 public:
+    typedef T ValueType;
 
     /* ------------------------ Constructors ---------------------- */
 

--- a/libs/math/vector.h
+++ b/libs/math/vector.h
@@ -64,6 +64,8 @@ typedef Vector<unsigned char,3> Vec3uc;
 typedef Vector<unsigned char,4> Vec4uc;
 typedef Vector<unsigned char,5> Vec5uc;
 typedef Vector<unsigned char,6> Vec6uc;
+typedef Vector<short,64> Vec64s;
+typedef Vector<unsigned short,128> Vec128us;
 typedef Vector<std::size_t,1> Vec1st;
 typedef Vector<std::size_t,2> Vec2st;
 typedef Vector<std::size_t,3> Vec3st;

--- a/libs/math/vector.h
+++ b/libs/math/vector.h
@@ -80,6 +80,7 @@ template <typename T, int N>
 class Vector
 {
 public:
+    typedef T ValueType;
 
     /* ------------------------ Constructors ---------------------- */
 

--- a/libs/sfm/bundler_matching.cc
+++ b/libs/sfm/bundler_matching.cc
@@ -18,6 +18,7 @@
 #include "sfm/sift.h"
 #include "sfm/ransac.h"
 #include "sfm/bundler_matching.h"
+#include "sfm/cascade_hashing.h"
 #include "sfm/exhaustive_matching.h"
 
 SFM_NAMESPACE_BEGIN
@@ -31,6 +32,9 @@ Matching::Matching (Options const& options, Progress* progress)
     {
         case MATCHER_EXHAUSTIVE:
             this->matcher.reset(new ExhaustiveMatching());
+            break;
+        case MATCHER_CASCADE_HASHING:
+            this->matcher.reset(new CascadeHashing());
             break;
         default:
             throw std::runtime_error("Unhandled matcher type");

--- a/libs/sfm/bundler_matching.h
+++ b/libs/sfm/bundler_matching.h
@@ -51,7 +51,8 @@ class Matching
 public:
     enum MatcherType
     {
-        MATCHER_EXHAUSTIVE
+        MATCHER_EXHAUSTIVE,
+        MATCHER_CASCADE_HASHING
     };
 
     /** Options for feature matching. */

--- a/libs/sfm/cascade_hashing.cc
+++ b/libs/sfm/cascade_hashing.cc
@@ -1,0 +1,260 @@
+/*
+ * Copyright (C) 2016, Andre Schulz
+ * TU Darmstadt - Graphics, Capture and Massively Parallel Computing
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD 3-Clause license. See the LICENSE.txt file for details.
+ */
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+#include "sfm/cascade_hashing.h"
+
+SFM_NAMESPACE_BEGIN
+
+void
+CascadeHashing::GlobalData::generate_proj_matrices (Options const& opts)
+{
+    generate_proj_matrices(
+        &this->sift.prim_proj_mat,
+        &this->sift.sec_proj_mats,
+        opts);
+    generate_proj_matrices(
+        &this->surf.prim_proj_mat,
+        &this->surf.sec_proj_mats,
+        opts);
+}
+
+/* ---------------------------------------------------------------- */
+
+void
+CascadeHashing::init (bundler::ViewportList* viewports)
+{
+    ExhaustiveMatching::init(viewports);
+
+    util::WallTimer timer;
+    this->local_data_sift.clear();
+    this->local_data_sift.resize(viewports->size());
+    this->local_data_surf.clear();
+    this->local_data_surf.resize(viewports->size());
+
+    this->global_data.generate_proj_matrices(this->cashash_opts);
+
+    /* Convert feature descriptors to zero mean. */
+    math::Vec128f sift_avg;
+    math::Vec64f surf_avg;
+    compute_avg_descriptors(this->processed_feature_sets, &sift_avg, &surf_avg);
+
+#pragma omp parallel for schedule(dynamic)
+    for (std::size_t i = 0; i < viewports->size(); i++)
+    {
+        LocalData* ld_sift = &this->local_data_sift[i];
+        LocalData* ld_surf = &this->local_data_surf[i];
+
+        ProcessedFeatureSet const& pfs = this->processed_feature_sets[i];
+        std::vector<math::Vec128f> sift_zero_mean_descs;
+        std::vector<math::Vec64f> surf_zero_mean_descs;
+        this->compute_zero_mean_descs(&sift_zero_mean_descs,
+            &surf_zero_mean_descs, pfs.sift_descr, pfs.surf_descr, sift_avg,
+            surf_avg);
+
+        this->compute(ld_sift, ld_surf, sift_zero_mean_descs,
+            surf_zero_mean_descs, this->global_data, this->cashash_opts);
+    }
+    std::cout << "Computing cascade hashes took " << timer.get_elapsed()
+        << " ms" << std::endl;
+}
+
+void
+CascadeHashing::pairwise_match (int view_1_id, int view_2_id,
+    Matching::Result* result) const
+{
+    /* SIFT matching. */
+    ProcessedFeatureSet const& pfs_1 = this->processed_feature_sets[view_1_id];
+    ProcessedFeatureSet const& pfs_2 = this->processed_feature_sets[view_2_id];
+    LocalData const& ld_sift_1 = this->local_data_sift[view_1_id];
+    LocalData const& ld_sift_2 = this->local_data_sift[view_2_id];
+    Matching::Result sift_result;
+    if (pfs_1.sift_descr.size() > 0)
+    {
+        this->twoway_match(this->opts.sift_matching_opts,
+            ld_sift_1, ld_sift_2,
+            pfs_1.sift_descr, pfs_2.sift_descr,
+            &sift_result, this->cashash_opts);
+        Matching::remove_inconsistent_matches(&sift_result);
+    }
+
+    /* SURF matching. */
+    LocalData const& ld_surf_1 = this->local_data_surf[view_1_id];
+    LocalData const& ld_surf_2 = this->local_data_surf[view_2_id];
+    Matching::Result surf_result;
+    if (pfs_1.surf_descr.size() > 0)
+    {
+        this->twoway_match(this->opts.surf_matching_opts,
+            ld_surf_1, ld_surf_2,
+            pfs_1.surf_descr, pfs_2.surf_descr,
+            &surf_result, this->cashash_opts);
+        Matching::remove_inconsistent_matches(&surf_result);
+    }
+
+    /* TODO: The following code is the same as in
+     *       ExhaustiveMatching::pairwise_match() and could be moved into a
+     *       separate function to avoid code duplication.
+     */
+    /* Fix offsets in the matching result. */
+    std::size_t other_surf_offset = pfs_2.sift_descr.size();
+    if (other_surf_offset > 0)
+        for (std::size_t i = 0; i < surf_result.matches_1_2.size(); ++i)
+            if (surf_result.matches_1_2[i] >= 0)
+                surf_result.matches_1_2[i] += other_surf_offset;
+
+    std::size_t this_surf_offset = pfs_1.sift_descr.size();
+    if (this_surf_offset > 0)
+        for (std::size_t i = 0; i < surf_result.matches_2_1.size(); ++i)
+            if (surf_result.matches_2_1[i] >= 0)
+                surf_result.matches_2_1[i] += this_surf_offset;
+
+    /* Create a combined matching result. */
+    std::size_t this_num_descriptors = pfs_1.sift_descr.size()
+        + pfs_1.surf_descr.size();
+    std::size_t other_num_descriptors = pfs_2.sift_descr.size()
+        + pfs_2.surf_descr.size();
+
+    result->matches_1_2.clear();
+    result->matches_1_2.reserve(this_num_descriptors);
+    result->matches_1_2.insert(result->matches_1_2.end(),
+        sift_result.matches_1_2.begin(), sift_result.matches_1_2.end());
+    result->matches_1_2.insert(result->matches_1_2.end(),
+        surf_result.matches_1_2.begin(), surf_result.matches_1_2.end());
+
+    result->matches_2_1.clear();
+    result->matches_2_1.reserve(other_num_descriptors);
+    result->matches_2_1.insert(result->matches_2_1.end(),
+        sift_result.matches_2_1.begin(), sift_result.matches_2_1.end());
+    result->matches_2_1.insert(result->matches_2_1.end(),
+        surf_result.matches_2_1.begin(), surf_result.matches_2_1.end());
+}
+
+void
+CascadeHashing::compute(
+    LocalData* ld_sift, LocalData* ld_surf,
+    std::vector<math::Vec128f> const& sift_zero_mean_descs,
+    std::vector<math::Vec64f> const& surf_zero_mean_descs,
+    GlobalData const& cashash_global_data,
+    Options const& cashash_opts)
+{
+    /* Compute cascade hashes of zero mean SIFT/SURF descriptors. */
+    compute_cascade_hashes(
+        sift_zero_mean_descs,
+        &ld_sift->comp_hash_data,
+        &ld_sift->bucket_grps_bucket_ids,
+        cashash_global_data.sift.prim_proj_mat,
+        cashash_global_data.sift.sec_proj_mats,
+        cashash_opts);
+    compute_cascade_hashes(
+        surf_zero_mean_descs,
+        &ld_surf->comp_hash_data,
+        &ld_surf->bucket_grps_bucket_ids,
+        cashash_global_data.surf.prim_proj_mat,
+        cashash_global_data.surf.sec_proj_mats,
+        cashash_opts);
+
+    /* Build buckets. */
+    build_buckets(
+        &ld_sift->bucket_grps_feature_ids,
+        ld_sift->bucket_grps_bucket_ids,
+        sift_zero_mean_descs.size(),
+        cashash_opts);
+    build_buckets(
+        &ld_surf->bucket_grps_feature_ids,
+        ld_surf->bucket_grps_bucket_ids,
+        surf_zero_mean_descs.size(),
+        cashash_opts);
+}
+
+/* ---------------------------------------------------------------- */
+
+void
+CascadeHashing::compute_avg_descriptors (ProcessedFeatureSets const& pfs,
+    math::Vec128f* sift_avg, math::Vec64f* surf_avg)
+{
+    math::Vec128f sift_vec_sum(0.0f);
+    math::Vec64f surf_vec_sum(0.0f);
+    std::size_t num_sift_descs_total = 0;
+    std::size_t num_surf_descs_total = 0;
+
+    /* Compute sum of all SIFT/SURF descriptors. */
+    for (std::size_t i = 0; i < pfs.size(); i++)
+    {
+        SiftDescriptors const& sift_descr = pfs[i].sift_descr;
+        SurfDescriptors const& surf_descr = pfs[i].surf_descr;
+
+        std::size_t num_sift_descriptors = sift_descr.size();
+        std::size_t num_surf_descriptors = surf_descr.size();
+        num_sift_descs_total += num_sift_descriptors;
+        num_surf_descs_total += num_surf_descriptors;
+
+        for (std::size_t j = 0; j < num_sift_descriptors; j++)
+            for (int k = 0; k < 128; k++)
+                sift_vec_sum[k] += sift_descr[j][k] / 255.0f;
+
+        for (std::size_t j = 0; j < num_surf_descriptors; j++)
+            for (int k = 0; k < 64; k++)
+                surf_vec_sum[k] += surf_descr[j][k] / 127.0f;
+    }
+
+    /* Compute average vectors for SIFT/SURF. */
+    *sift_avg = sift_vec_sum / num_sift_descs_total;
+    *surf_avg = surf_vec_sum / num_surf_descs_total;
+}
+
+void
+CascadeHashing::compute_zero_mean_descs(
+    std::vector<math::Vec128f>* sift_zero_mean_descs,
+    std::vector<math::Vec64f>* surf_zero_mean_descs,
+    SiftDescriptors const& sift_descs, SurfDescriptors const& surf_descs,
+    math::Vec128f const& sift_avg, math::Vec64f const& surf_avg)
+{
+    /* Compute zero mean descriptors. */
+    sift_zero_mean_descs->resize(sift_descs.size());
+    for (std::size_t i = 0; i < sift_descs.size(); i++)
+        for (int j = 0; j < 128; j++)
+            (*sift_zero_mean_descs)[i][j] = sift_descs[i][j] / 255.0f - sift_avg[j];
+
+    surf_zero_mean_descs->resize(surf_descs.size());
+    for (std::size_t i = 0; i < surf_descs.size(); i++)
+        for (int j = 0; j < 64; j++)
+            (*surf_zero_mean_descs)[i][j] = surf_descs[i][j] / 127.0f - surf_avg[j];
+}
+
+/* ---------------------------------------------------------------- */
+
+void
+CascadeHashing::build_buckets(
+    BucketGroupsFeatures *bucket_grps_feature_ids,
+    BucketGroupsBuckets const& bucket_grps_bucket_ids,
+    size_t num_descs,
+    Options const& opts)
+{
+    uint8_t const num_bucket_grps = opts.num_bucket_groups;
+    uint8_t const num_bucket_bits = opts.num_bucket_bits;
+    uint32_t const num_buckets_per_group = 1 << num_bucket_bits;
+
+    bucket_grps_feature_ids->resize(num_bucket_grps);
+
+    for (uint8_t grp_idx = 0; grp_idx < num_bucket_grps; grp_idx++)
+    {
+        BucketGroupFeatures &bucket_grp_features = (*bucket_grps_feature_ids)[grp_idx];
+        bucket_grp_features.resize(num_buckets_per_group);
+        for (size_t i = 0; i < num_descs; i++)
+        {
+            uint16_t bucket_id = bucket_grps_bucket_ids[grp_idx][i];
+            bucket_grp_features[bucket_id].emplace_back(i);
+        }
+    }
+}
+
+SFM_NAMESPACE_END

--- a/libs/sfm/cascade_hashing.h
+++ b/libs/sfm/cascade_hashing.h
@@ -1,0 +1,481 @@
+/*
+ * Copyright (C) 2016, Andre Schulz
+ * TU Darmstadt - Graphics, Capture and Massively Parallel Computing
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD 3-Clause license. See the LICENSE.txt file for details.
+ */
+
+#ifndef SFM_CASCADE_HASHING_HEADER
+#define SFM_CASCADE_HASHING_HEADER
+
+#include <cstring>
+#include <iostream>
+#include <random>
+
+#include <popcntintrin.h>
+
+#include "math/vector.h"
+#include "sfm/defines.h"
+#include "sfm/exhaustive_matching.h"
+#include "sfm/matching.h"
+#include "sfm/sift.h"
+#include "sfm/surf.h"
+#include "util/system.h"
+#include "util/timer.h"
+
+SFM_NAMESPACE_BEGIN
+
+class CascadeHashing : public ExhaustiveMatching
+{
+public:
+    struct Options
+    {
+        /** Number of bucket groups. */
+        uint8_t num_bucket_groups = 6;
+
+        /** Number of buckets (2^num_bucket_bits) per bucket group. */
+        uint8_t num_bucket_bits = 8;
+
+        /** Minimum number of top ranked candidates to collect. */
+        uint16_t min_num_candidates = 6;
+
+        /** Maximum number of top ranked candidates to collect. */
+        uint16_t max_num_candidates = 10;
+    };
+
+    /**
+     * Initialize matcher by computing cascade hashes of the SIFT/SURF
+     * descriptors.
+     */
+    void init (bundler::ViewportList* viewports) override;
+
+    /** Matches all feature types yielding a single matching result. */
+    void pairwise_match (int view_1_id, int view_2_id,
+        Matching::Result* result) const override;
+
+private:
+    struct LocalData;
+
+    /**
+     * Matches all elements in set 1 to all elements in set 2 and vice versa.
+     * Works similarly to sfm::Matching::twoway_match().
+     */
+    template <typename D>
+    void twoway_match (Matching::Options const& matching_opts,
+        LocalData const& set_1, LocalData const& set_2,
+        D const& set_1_descs, D const& set_2_descs,
+        Matching::Result* matches, Options const& cashash_opts) const;
+
+    /**
+     * Matches all elements in set 1 to all elements in set 2.
+     * Works similarly to sfm::Matching::oneway_match().
+     */
+    template <typename D>
+    void oneway_match (Matching::Options const& matching_opts,
+        LocalData const& set_1, LocalData const& set_2,
+        D const& set_1_descs, D const& set_2_descs,
+        std::vector<int>* result, Options const& cashash_opts) const;
+
+    /**
+     * Cascade hashing projection matrices. T shall be a vector with the same
+     * number of elements as the feature descriptor, i.e. Vec128f for SIFT and
+     * Vec64f for SURF.
+     */
+    template <typename T>
+    struct ProjMats
+    {
+        /**
+         * Primary projection matrix. The number of vectors/Ts determines the
+         * size of the bit vector that is computed and used for computing the
+         * hamming distance later on. The size of prim_proj_mat is set to the
+         * size of the feature descriptors
+         * (see GlobalData::generate_proj_matrices()), i.e. 128 for SIFT and 64
+         * for SURF.
+         */
+        std::vector<T> prim_proj_mat;
+
+        /**
+         * Secondary projection matrices. The number of Ts is the number of
+         * buckets per bucket group (see Options::num_bucket_bits).
+         * The size of sec_proj_mats is the number of bucket groups.
+         */
+        std::vector<std::vector<T>> sec_proj_mats;
+    };
+
+    typedef ProjMats<math::Vec64f>  ProjMatsSurf;
+    typedef ProjMats<math::Vec128f> ProjMatsSift;
+
+    /**
+     * GlobalData contains the primary and secondary projection matrices
+     * for each descriptor type. These are used to compute the hashes of each
+     * feature and to which buckets a feature is assigned. It is global in the
+     * sense that it is the same and used for all images.
+     */
+    class GlobalData
+    {
+    public:
+        void generate_proj_matrices (Options const& cashash_opts);
+
+        ProjMatsSift sift;
+        ProjMatsSurf surf;
+
+    private:
+        template <typename T>
+        void generate_proj_matrices (std::vector<T>* prim_hash,
+            std::vector<std::vector<T>>* sec_hash, Options const& cashash_opts);
+    };
+
+    typedef std::vector<std::size_t> BucketFeatureIDs;
+    typedef std::vector<BucketFeatureIDs> BucketGroupFeatures;
+    typedef std::vector<BucketGroupFeatures> BucketGroupsFeatures;
+
+    typedef std::vector<uint16_t> BucketIDs;
+    typedef std::vector<BucketIDs> BucketGroupsBuckets;
+
+    /** Per-image local data. */
+    struct LocalData
+    {
+        /**
+         * Compressed hash data. 2x uint64_t for SIFT and 1x uint64_t for SURF.
+         * Each uint64_t is a bit vector which represents the inverted signs of
+         * the dot products of the feature vector with the vectors in
+         * ProjMats::prim_proj_mat. It is compressed in the sense that the bits
+         * are tightly packed into uint64_ts.
+         */
+        std::vector<uint64_t> comp_hash_data;
+
+        /**
+         * Vector of bucket IDs to which a feature is assigned for each bucket
+         * group, i.e. bucket_grps_bucket_ids[2][64] = 8 means that in bucket
+         * group 2 feature 64 is assigned to bucket 8.
+         */
+        BucketGroupsBuckets bucket_grps_bucket_ids;
+
+        /**
+         * Vector of feature IDs for each bucket of a bucket group, i.e.
+         * bucket_grps_feature_ids[2][8][4] = 6 means that the 4th feature in
+         * bucket 8 of bucket group 2 is the feature with the ID 6.
+         */
+        BucketGroupsFeatures bucket_grps_feature_ids;
+    };
+
+    /** Compute cascade hashing data from SIFT and SURF descriptors. */
+    void compute (LocalData* ld_sift, LocalData* ld_surf,
+        std::vector<math::Vec128f> const& sift_zero_mean_descs,
+        std::vector<math::Vec64f> const& surf_zero_mean_descs,
+        GlobalData const& cashash_global_data, Options const& cashash_opts);
+
+    /** Convert discretized SIFT/SURF descriptors to zero mean. */
+    void preprocess (ProcessedFeatureSets const& pfs,
+        std::vector<math::Vec128f>* sift_zero_mean_descs,
+        std::vector<math::Vec64f>* surf_zero_mean_descs);
+
+    /** Compute average descriptors of given feature sets. */
+    void compute_avg_descriptors (ProcessedFeatureSets const& pfs,
+        math::Vec128f* sift_avg, math::Vec64f* surf_avg);
+
+    /** Compute zero mean descriptors using given average vectors. */
+    void compute_zero_mean_descs(
+        std::vector<math::Vec128f>* sift_zero_mean_descs,
+        std::vector<math::Vec64f>* surf_zero_mean_descs,
+        SiftDescriptors const& sift_descs, SurfDescriptors const& surf_descs,
+        math::Vec128f const& sift_avg, math::Vec64f const& surf_avg);
+
+    /** Compute cascade hashes of zero mean SIFT/SURF descriptors. */
+    template <typename T>
+    void compute_cascade_hashes (std::vector<T> const& zero_mean_descs,
+        std::vector<uint64_t>* comp_hash_data,
+        BucketGroupsBuckets* bucket_grps_bucket_ids,
+        std::vector<T> const& prim_proj_mat,
+        std::vector<std::vector<T>> const& sec_proj_mats, Options const& cashash_opts);
+
+    /** Assign features to a bucket for each bucket group. */
+    void build_buckets (BucketGroupsFeatures* bucket_grps_feature_ids,
+        BucketGroupsBuckets const& bucket_grps_bucket_ids, size_t num_descs,
+        Options const& cashash_opts);
+
+    /**
+     * Collect features from the bucket from each bucket group to which
+     * feature_id is assigned and group them according to their hamming
+     * distance to the feature.
+     */
+    template <int DIMHASH>
+    void collect_features_from_buckets (
+        std::vector<std::vector<uint32_t>>* grouped_features,
+        size_t feature_id, std::vector<bool>* data_index_used,
+        BucketGroupsBuckets const& bucket_grps_bucket_ids,
+        BucketGroupsFeatures const& bucket_grps_feature_ids,
+        uint64_t const* comp_hash_data1,
+        std::vector<uint64_t> const& comp_hash_data2) const;
+
+    /**
+     * Collect the features with the smallest hamming distance from
+     * grouped_features into top_candidates.
+     */
+    void collect_top_ranked_candidates (std::vector<uint32_t>* top_candidates,
+        std::vector<std::vector<uint32_t>> const& grouped_features,
+        uint8_t dim_hash_data, uint16_t min_num_candidates,
+        uint16_t max_num_candidates) const;
+
+private:
+    GlobalData global_data;
+    std::vector<LocalData> local_data_sift;
+    std::vector<LocalData> local_data_surf;
+    Options cashash_opts;
+};
+
+/* ---------------------------------------------------------------- */
+
+template <typename T>
+void CascadeHashing::GlobalData::generate_proj_matrices (
+    std::vector<T>* prim_hash, std::vector<std::vector<T>>* sec_hash,
+    Options const& cashash_opts)
+{
+    int const dim_desc = T::dim();
+    int const dim_hash_data = dim_desc;
+
+    prim_hash->resize(dim_hash_data);
+
+    /* Setup PRNG. */
+    std::mt19937 prng_mt(0);
+    std::normal_distribution<> dis(0, 1);
+
+    /* Generate values for primary hashing function. */
+    for (uint8_t i = 0; i < dim_hash_data; i++)
+        for (uint8_t j = 0; j < dim_desc; j++)
+            (*prim_hash)[i][j] = dis(prng_mt);
+
+    uint8_t const num_bucket_groups = cashash_opts.num_bucket_groups;
+    uint8_t const num_bucket_bits = cashash_opts.num_bucket_bits;
+
+    sec_hash->resize(num_bucket_groups, std::vector<T>(num_bucket_bits));
+
+    /* Generate values for secondary hashing function. */
+    for (uint8_t group_idx = 0; group_idx < num_bucket_groups; group_idx++)
+        for (uint8_t i = 0; i < num_bucket_bits; i++)
+            for (uint8_t j = 0; j < dim_desc; j++)
+                (*sec_hash)[group_idx][i][j] = dis(prng_mt);
+}
+
+/* ---------------------------------------------------------------- */
+
+template <typename T>
+void
+CascadeHashing::compute_cascade_hashes (std::vector<T> const& zero_mean_descs,
+    std::vector<uint64_t>* comp_hash_data,
+    BucketGroupsBuckets* bucket_grps_bucket_ids,
+    std::vector<T> const& prim_proj_mat,
+    std::vector<std::vector<T>> const& sec_proj_mats,
+    Options const& cashash_opts)
+{
+    int const dim_desc = T::dim();
+    int const dim_hash_data = dim_desc;
+    uint8_t const dim_comp_hash_data = dim_hash_data / 64;
+    uint8_t const num_bucket_bits = cashash_opts.num_bucket_bits;
+    uint8_t const num_bucket_grps = cashash_opts.num_bucket_groups;
+
+    /* Allocate memory. */
+    size_t num_descs = zero_mean_descs.size();
+    comp_hash_data->resize(num_descs * dim_comp_hash_data);
+    bucket_grps_bucket_ids->resize(num_bucket_grps, std::vector<uint16_t>(num_descs));
+
+    for (size_t i = 0; i < num_descs; i++)
+    {
+        T const& desc = zero_mean_descs[i];
+
+        /* Compute hash code. */
+        for (uint8_t j = 0; j < dim_comp_hash_data; j++)
+        {
+            uint64_t comp_hash = 0;
+            uint8_t data_start = j * 64;
+            uint8_t data_end = (j + 1) * 64;
+            for (uint8_t k = data_start; k < data_end; k++)
+            {
+                T const& proj_vec = prim_proj_mat[k];
+                float sum = desc.dot(proj_vec);
+                comp_hash = (comp_hash << 1) | (sum > 0.0f);
+            }
+            (*comp_hash_data)[i * dim_comp_hash_data + j] = comp_hash;
+        }
+
+        /* Determine the descriptor's bucket index for each bucket group. */
+        for (uint8_t grp_idx = 0; grp_idx < num_bucket_grps; grp_idx++)
+        {
+            uint16_t bucket_id = 0;
+            for (uint8_t bit_idx = 0; bit_idx < num_bucket_bits; bit_idx++)
+            {
+                T const& proj_vec = sec_proj_mats[grp_idx][bit_idx];
+                float sum = desc.dot(proj_vec);
+                bucket_id = (bucket_id << 1) | (sum > 0.0f);
+            }
+
+            (*bucket_grps_bucket_ids)[grp_idx][i] = bucket_id;
+        }
+    }
+}
+
+template <typename D>
+void
+CascadeHashing::twoway_match (Matching::Options const& matching_opts,
+    LocalData const& set_1, LocalData const& set_2,
+    D const& set_1_descs, D const& set_2_descs,
+    Matching::Result* matches, Options const& cashash_opts) const
+{
+    oneway_match(matching_opts, set_1, set_2, set_1_descs, set_2_descs,
+        &matches->matches_1_2,
+        cashash_opts);
+    oneway_match(matching_opts, set_2, set_1, set_2_descs, set_1_descs,
+        &matches->matches_2_1,
+        cashash_opts);
+}
+
+template <typename D>
+void
+CascadeHashing::oneway_match (Matching::Options const& matching_opts,
+    LocalData const& set_1, LocalData const& set_2,
+    D const& set_1_descs, D const& set_2_descs,
+    std::vector<int>* result, Options const& cashash_opts) const
+{
+    typedef typename D::value_type V;
+    typedef typename V::ValueType T;
+
+    size_t set_1_size = set_1_descs.size();
+    size_t set_2_size = set_2_descs.size();
+
+    if (set_1_size == 0 || set_2_size == 0)
+        return;
+
+    float const square_lowe_thres = MATH_POW2(matching_opts.lowe_ratio_threshold);
+    float const square_dist_thres = MATH_POW2(matching_opts.distance_threshold);
+
+    uint16_t const min_num_candidates = cashash_opts.min_num_candidates;
+    uint16_t const max_num_candidates = cashash_opts.max_num_candidates;
+    int const descriptor_length = V::dim();
+    uint8_t const dim_hash_data = descriptor_length;
+    uint32_t const dim_comp_hash_data = dim_hash_data / 64;
+
+    result->resize(set_1_size, -1);
+    std::vector<bool> data_index_used(set_2_size);
+    std::vector<std::vector<uint32_t> > grouped_features(dim_hash_data + 1);
+    std::vector<uint32_t> top_candidates;
+
+    top_candidates.reserve(max_num_candidates);
+
+    std::unique_ptr<T> tmp(new T[max_num_candidates * descriptor_length]);
+    NearestNeighbor<T> nn;
+    nn.set_elements(tmp.get());
+    nn.set_element_dimensions(descriptor_length);
+
+    for (size_t i = 0; i < set_1_size; i++)
+    {
+        std::fill(data_index_used.begin(), data_index_used.end(), false);
+
+        for (size_t j = 0; j < grouped_features.size(); j++)
+            grouped_features[j].clear();
+
+        top_candidates.clear();
+
+        /* Fetch candidate features from the buckets in each group. */
+        collect_features_from_buckets<dim_hash_data>(
+            &grouped_features,
+            i,
+            &data_index_used,
+            set_1.bucket_grps_bucket_ids,
+            set_2.bucket_grps_feature_ids,
+            &set_1.comp_hash_data[i * dim_comp_hash_data],
+            set_2.comp_hash_data);
+
+        /* Add closest candidates by Hamming distance to top_candidates vector. */
+        collect_top_ranked_candidates(
+            &top_candidates,
+            grouped_features,
+            dim_hash_data,
+            min_num_candidates,
+            max_num_candidates);
+
+        /* Copy top candidates' descriptors into a contiguous array. */
+        for (size_t j = 0; j < top_candidates.size(); j++)
+        {
+            uint32_t candidate_id = top_candidates[j];
+            std::memcpy(tmp.get() + j * descriptor_length,
+                set_2_descs[candidate_id].begin(),
+                sizeof(V));
+        }
+
+        typename NearestNeighbor<T>::Result nn_result;
+        nn.set_num_elements(top_candidates.size());
+        nn.find(set_1_descs[i].begin(), &nn_result);
+
+        if (nn_result.dist_1st_best > square_dist_thres)
+            continue;
+
+        if (static_cast<float>(nn_result.dist_1st_best)
+            / static_cast<float>(nn_result.dist_2nd_best)
+            > square_lowe_thres)
+            continue;
+
+        result->at(i) = top_candidates[nn_result.index_1st_best];
+    }
+}
+
+template <int DIMHASH>
+void
+CascadeHashing::collect_features_from_buckets (
+    std::vector<std::vector<uint32_t>>* grouped_features,
+    size_t feature_id, std::vector<bool>* data_index_used,
+    BucketGroupsBuckets const& bucket_grps_bucket_ids,
+    BucketGroupsFeatures const& bucket_grps_feature_ids,
+    uint64_t const* comp_hash_data1,
+    std::vector<uint64_t> const& comp_hash_data2) const
+{
+    size_t num_bucket_grps = bucket_grps_bucket_ids.size();
+    for (size_t grp_idx = 0; grp_idx < num_bucket_grps; grp_idx++)
+    {
+        uint8_t bucket_id = bucket_grps_bucket_ids[grp_idx][feature_id];
+        BucketFeatureIDs const& bucket_feature_ids = bucket_grps_feature_ids[grp_idx][bucket_id];
+
+        for (size_t j = 0; j < bucket_feature_ids.size(); j++)
+        {
+            size_t candidate_id = bucket_feature_ids[j];
+            if ((*data_index_used)[candidate_id])
+                continue;
+
+            uint64_t const *ptr2 = &comp_hash_data2[candidate_id * DIMHASH / 64];
+            int hamming_dist = 0;
+            for (int k = 0; k < (DIMHASH / 64); k++)
+                hamming_dist += _mm_popcnt_u64(comp_hash_data1[k] ^ ptr2[k]);
+
+            (*grouped_features)[hamming_dist].emplace_back(candidate_id);
+            (*data_index_used)[candidate_id] = true;
+        }
+    }
+}
+
+inline void
+CascadeHashing::collect_top_ranked_candidates (
+    std::vector<uint32_t>* top_candidates,
+    std::vector<std::vector<uint32_t>> const& grouped_features,
+    uint8_t dim_hash_data, uint16_t min_num_candidates,
+    uint16_t max_num_candidates) const
+{
+    for (uint16_t hash_dist = 0; hash_dist <= dim_hash_data; hash_dist++)
+    {
+        for (size_t j = 0; j < grouped_features[hash_dist].size(); j++)
+        {
+            uint32_t idx2 = grouped_features[hash_dist][j];
+            top_candidates->emplace_back(idx2);
+
+            if (top_candidates->size() >= max_num_candidates)
+                break;
+        }
+
+        if (top_candidates->size() >= min_num_candidates)
+            break;
+    }
+}
+
+SFM_NAMESPACE_END
+
+#endif /* SFM_CASCADE_HASHING_HEADER */

--- a/libs/sfm/exhaustive_matching.h
+++ b/libs/sfm/exhaustive_matching.h
@@ -40,15 +40,15 @@ public:
      * are at most 3 matches for 500 features, or 2 matches with 300 features.
      */
     int pairwise_match_lowres (int view_1_id, int view_2_id,
-        int num_features) const override;
+        std::size_t num_features) const override;
 
-private:
+protected:
 #if DISCRETIZE_DESCRIPTORS
-    typedef util::AlignedMemory<uint16_t, 16> SiftDescriptors;
-    typedef util::AlignedMemory<int16_t, 16> SurfDescriptors;
+    typedef util::AlignedMemory<math::Vec128us, 16> SiftDescriptors;
+    typedef util::AlignedMemory<math::Vec64s, 16> SurfDescriptors;
 #else
-    typedef util::AlignedMemory<float, 16> SiftDescriptors;
-    typedef util::AlignedMemory<float, 16> SurfDescriptors;
+    typedef util::AlignedMemory<math::Vec128f, 16> SiftDescriptors;
+    typedef util::AlignedMemory<math::Vec64f, 16> SurfDescriptors;
 #endif
 
     /** Internal initialization methods for SIFT/SURF features. */
@@ -58,11 +58,10 @@ private:
     struct ProcessedFeatureSet
     {
         SiftDescriptors sift_descr;
-        int num_sift_descriptors;
         SurfDescriptors surf_descr;
-        int num_surf_descriptors;
     };
-    std::vector<ProcessedFeatureSet> processed_feature_sets;
+    typedef std::vector<ProcessedFeatureSet> ProcessedFeatureSets;
+    ProcessedFeatureSets processed_feature_sets;
 };
 
 SFM_NAMESPACE_END

--- a/libs/sfm/matching.h
+++ b/libs/sfm/matching.h
@@ -117,7 +117,8 @@ Matching::oneway_match (Options const& options,
     float const square_lowe_thres = MATH_POW2(options.lowe_ratio_threshold);
     float const square_dist_thres = MATH_POW2(options.distance_threshold);
     NearestNeighbor<T> nn;
-    nn.set_elements(set_2, set_2_size);
+    nn.set_elements(set_2);
+    nn.set_num_elements(set_2_size);
     nn.set_element_dimensions(options.descriptor_length);
 
     for (int i = 0; i < set_1_size; ++i)

--- a/libs/sfm/matching_base.h
+++ b/libs/sfm/matching_base.h
@@ -49,7 +49,7 @@ public:
      * are at most 3 matches for 500 features, or 2 matches with 300 features.
      */
     virtual int pairwise_match_lowres (int view_1_id, int view_2_id,
-        int num_features) const = 0;
+        std::size_t num_features) const = 0;
 
     Options opts;
 };

--- a/libs/sfm/nearest_neighbor.h
+++ b/libs/sfm/nearest_neighbor.h
@@ -58,9 +58,11 @@ public:
 public:
     NearestNeighbor (void);
     /** For SfM, this is the descriptor memory block. */
-    void set_elements (T const* elements, int num_elements);
+    void set_elements (T const* elements);
     /** For SfM, this is the descriptor length. */
     void set_element_dimensions (int element_dimensions);
+    /** For SfM, this is the number of descriptors. */
+    void set_num_elements (int num_elements);
     /** Find the nearest neighbor of 'query'. */
     void find (T const* query, Result* result) const;
 
@@ -85,10 +87,9 @@ NearestNeighbor<T>::NearestNeighbor (void)
 
 template <typename T>
 inline void
-NearestNeighbor<T>::set_elements (T const* elements, int num_elements)
+NearestNeighbor<T>::set_elements (T const* elements)
 {
     this->elements = elements;
-    this->num_elements = num_elements;
 }
 
 template <typename T>
@@ -96,6 +97,13 @@ inline void
 NearestNeighbor<T>::set_element_dimensions (int element_dimensions)
 {
     this->dimensions = element_dimensions;
+}
+
+template <typename T>
+inline void
+NearestNeighbor<T>::set_num_elements (int num_elements)
+{
+    this->num_elements = num_elements;
 }
 
 template <typename T>

--- a/tests/sfm/gtest_nearest_neighbor.cc
+++ b/tests/sfm/gtest_nearest_neighbor.cc
@@ -51,7 +51,8 @@ TEST(NearestNeighborTest, TestSingnedShort)
 
     sfm::NearestNeighbor<short>::Result result;
     sfm::NearestNeighbor<short> nn;
-    nn.set_elements(elements.data(), 4);
+    nn.set_elements(elements.data());
+    nn.set_num_elements(4);
     nn.set_element_dimensions(8);
 
     short query1[8] = { 127, 0, 0, 0, 0, 0, 0, 0 };
@@ -117,7 +118,8 @@ TEST(NearestNeighborTest, TestUnsignedShort)
 
     sfm::NearestNeighbor<unsigned short>::Result result;
     sfm::NearestNeighbor<unsigned short> nn;
-    nn.set_elements(elements.data(), 2);
+    nn.set_elements(elements.data());
+    nn.set_num_elements(2);
     nn.set_element_dimensions(8);
 
     unsigned short query1[8] = { 255, 0, 0, 0, 0, 0, 0, 0 };
@@ -166,7 +168,8 @@ TEST(NearestNeighborTest, TestFloat)
 
     sfm::NearestNeighbor<float>::Result result;
     sfm::NearestNeighbor<float> nn;
-    nn.set_elements(elements.data(), 3);
+    nn.set_elements(elements.data());
+    nn.set_num_elements(3);
     nn.set_element_dimensions(4);
 
     float query1[4] = { 1.0f, 0.0f, 0.0f, 0.0f };


### PR DESCRIPTION
Using cascade hashing for feature matching trades a slight drop in matching
accuracy for a speed-up of an order of magnitude
Speed-up over bruteforce matching on the citywall-20140923 dataset:
1x Intel Core i7-3930K   : ~20.6x
2x Intel Xeon E5-2687W v3: ~18.1x