### PR TITLE
Refactor matching code

### DIFF
--- a/apps/sfmrecon/sfmrecon.cc
+++ b/apps/sfmrecon/sfmrecon.cc
@@ -116,7 +116,8 @@ features_and_matching (mve::Scene::Ptr scene, AppSettings const& conf,
     {
         util::WallTimer timer;
         sfm::bundler::Matching bundler_matching(matching_opts);
-        bundler_matching.compute(*viewports, pairwise_matching);
+        bundler_matching.init(viewports);
+        bundler_matching.compute(pairwise_matching);
         std::cout << "Matching took " << timer.get_elapsed()
             << " ms." << std::endl;
         log_message(conf, "Feature matching took "

--- a/libs/sfm/exhaustive_matching.cc
+++ b/libs/sfm/exhaustive_matching.cc
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2015, Simon Fuhrmann
+ * TU Darmstadt - Graphics, Capture and Massively Parallel Computing
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD 3-Clause license. See the LICENSE.txt file for details.
+ */
+
+#include "sfm/exhaustive_matching.h"
+
+SFM_NAMESPACE_BEGIN
+
+#if DISCRETIZE_DESCRIPTORS
+namespace
+{
+    void
+    convert_descriptor (Sift::Descriptor const& descr, unsigned short* data)
+    {
+        for (int i = 0; i < 128; ++i)
+        {
+            float value = descr.data[i];
+            value = math::clamp(value, 0.0f, 1.0f);
+            value = math::round(value * 255.0f);
+            data[i] = static_cast<unsigned char>(value);
+        }
+    }
+
+    void
+    convert_descriptor (Surf::Descriptor const& descr, signed short* data)
+    {
+        for (int i = 0; i < 64; ++i)
+        {
+            float value = descr.data[i];
+            value = math::clamp(value, -1.0f, 1.0f);
+            value = math::round(value * 127.0f);
+            data[i] = static_cast<signed char>(value);
+        }
+    }
+#else // DISCRETIZE_DESCRIPTORS
+    void
+    convert_descriptor (Sift::Descriptor const& descr, float* data)
+    {
+        std::copy(descr.data.begin(), descr.data.end(), data);
+    }
+
+    void
+    convert_descriptor (Surf::Descriptor const& descr, float* data)
+    {
+        std::copy(descr.data.begin(), descr.data.end(), data);
+    }
+#endif // DISCRETIZE_DESCRIPTORS
+}
+
+void
+ExhaustiveMatching::init (bundler::ViewportList* viewports)
+{
+    this->processed_feature_sets.clear();
+    this->processed_feature_sets.resize(viewports->size());
+
+    for (size_t i = 0; i < viewports->size(); i++)
+    {
+        FeatureSet const& fs = (*viewports)[i].features;
+        ProcessedFeatureSet& pfs = this->processed_feature_sets[i];
+
+        this->init_sift(&pfs.sift_descr, fs.sift_descriptors);
+        pfs.num_sift_descriptors = fs.sift_descriptors.size();
+
+        this->init_surf(&pfs.surf_descr, fs.surf_descriptors);
+        pfs.num_surf_descriptors = fs.surf_descriptors.size();
+    }
+}
+
+void
+ExhaustiveMatching::init_sift (SiftDescriptors* dst,
+    Sift::Descriptors const& src)
+{
+    /* Prepare and copy to data structures. */
+    dst->resize(src.size() * 128);
+
+#if DISCRETIZE_DESCRIPTORS
+    uint16_t* ptr = dst->data();
+#else
+    float* ptr = dst->data();
+#endif
+    for (std::size_t i = 0; i < src.size(); ++i, ptr += 128)
+    {
+        Sift::Descriptor const& d = src[i];
+        convert_descriptor(d, ptr);
+    }
+}
+
+void
+ExhaustiveMatching::init_surf (SurfDescriptors* dst,
+    Surf::Descriptors const& src)
+{
+    /* Prepare and copy to data structures. */
+    dst->resize(src.size() * 64);
+
+#if DISCRETIZE_DESCRIPTORS
+    int16_t* ptr = dst->data();
+#else
+    float* ptr = dst->data();
+#endif
+    for (std::size_t i = 0; i < src.size(); ++i, ptr += 64)
+    {
+        Surf::Descriptor const& d = src[i];
+        convert_descriptor(d, ptr);
+    }
+}
+
+void
+ExhaustiveMatching::pairwise_match (int view_1_id, int view_2_id,
+    Matching::Result* result) const
+{
+    ProcessedFeatureSet const& pfs_1 = this->processed_feature_sets[view_1_id];
+    ProcessedFeatureSet const& pfs_2 = this->processed_feature_sets[view_2_id];
+
+    /* SIFT matching. */
+    Matching::Result sift_result;
+    if (pfs_1.num_sift_descriptors > 0)
+    {
+        Matching::twoway_match(this->opts.sift_matching_opts,
+            pfs_1.sift_descr.data(), pfs_1.num_sift_descriptors,
+            pfs_2.sift_descr.data(), pfs_2.num_sift_descriptors,
+            &sift_result);
+        Matching::remove_inconsistent_matches(&sift_result);
+    }
+
+    /* SURF matching. */
+    Matching::Result surf_result;
+    if (pfs_1.num_surf_descriptors > 0)
+    {
+        Matching::twoway_match(this->opts.surf_matching_opts,
+            pfs_1.surf_descr.data(), pfs_1.num_surf_descriptors,
+            pfs_2.surf_descr.data(), pfs_2.num_surf_descriptors,
+            &surf_result);
+        Matching::remove_inconsistent_matches(&surf_result);
+    }
+
+    /* Fix offsets in the matching result. */
+    int other_surf_offset = pfs_2.num_sift_descriptors;
+    if (other_surf_offset > 0)
+        for (std::size_t i = 0; i < surf_result.matches_1_2.size(); ++i)
+            if (surf_result.matches_1_2[i] >= 0)
+                surf_result.matches_1_2[i] += other_surf_offset;
+
+    int this_surf_offset = pfs_1.num_sift_descriptors;
+    if (this_surf_offset > 0)
+        for (std::size_t i = 0; i < surf_result.matches_2_1.size(); ++i)
+            if (surf_result.matches_2_1[i] >= 0)
+                surf_result.matches_2_1[i] += this_surf_offset;
+
+    /* Create a combined matching result. */
+    std::size_t this_num_descriptors = pfs_1.num_sift_descriptors
+        + pfs_1.num_surf_descriptors;
+    std::size_t other_num_descriptors = pfs_2.num_sift_descriptors
+        + pfs_2.num_surf_descriptors;
+
+    result->matches_1_2.clear();
+    result->matches_1_2.reserve(this_num_descriptors);
+    result->matches_1_2.insert(result->matches_1_2.end(),
+        sift_result.matches_1_2.begin(), sift_result.matches_1_2.end());
+    result->matches_1_2.insert(result->matches_1_2.end(),
+        surf_result.matches_1_2.begin(), surf_result.matches_1_2.end());
+
+    result->matches_2_1.clear();
+    result->matches_2_1.reserve(other_num_descriptors);
+    result->matches_2_1.insert(result->matches_2_1.end(),
+        sift_result.matches_2_1.begin(), sift_result.matches_2_1.end());
+    result->matches_2_1.insert(result->matches_2_1.end(),
+        surf_result.matches_2_1.begin(), surf_result.matches_2_1.end());
+}
+
+int
+ExhaustiveMatching::pairwise_match_lowres (int view_1_id, int view_2_id,
+    int num_features) const
+{
+    ProcessedFeatureSet const& pfs_1 = this->processed_feature_sets[view_1_id];
+    ProcessedFeatureSet const& pfs_2 = this->processed_feature_sets[view_2_id];
+
+    /* SIFT lowres matching. */
+    if (pfs_1.num_sift_descriptors > 0)
+    {
+        Matching::Result sift_result;
+        Matching::twoway_match(this->opts.sift_matching_opts,
+            pfs_1.sift_descr.data(),
+            std::min(num_features, pfs_1.num_sift_descriptors),
+            pfs_2.sift_descr.data(),
+            std::min(num_features, pfs_2.num_sift_descriptors),
+            &sift_result);
+        return Matching::count_consistent_matches(sift_result);
+    }
+
+    /* SURF lowres matching. */
+    if (pfs_1.surf_descr.size() > 0)
+    {
+        Matching::Result surf_result;
+        Matching::twoway_match(this->opts.surf_matching_opts,
+            pfs_1.surf_descr.data(),
+            std::min(num_features, pfs_1.num_surf_descriptors),
+            pfs_2.surf_descr.data(),
+            std::min(num_features, pfs_2.num_surf_descriptors),
+            &surf_result);
+        return Matching::count_consistent_matches(surf_result);
+    }
+
+    return 0;
+}
+
+SFM_NAMESPACE_END
+

--- a/libs/sfm/exhaustive_matching.h
+++ b/libs/sfm/exhaustive_matching.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2015, Simon Fuhrmann
+ * TU Darmstadt - Graphics, Capture and Massively Parallel Computing
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD 3-Clause license. See the LICENSE.txt file for details.
+ */
+
+#ifndef SFM_EXHAUSTIVE_MATCHING_HEADER
+#define SFM_EXHAUSTIVE_MATCHING_HEADER
+
+#include "sfm/bundler_common.h"
+#include "sfm/defines.h"
+#include "sfm/matching_base.h"
+#include "sfm/nearest_neighbor.h"
+#include "sfm/sift.h"
+#include "sfm/surf.h"
+
+/* Whether to use floating point or 8-bit descriptors for matching. */
+#define DISCRETIZE_DESCRIPTORS 1
+
+SFM_NAMESPACE_BEGIN
+
+class ExhaustiveMatching : public MatchingBase
+{
+public:
+    ~ExhaustiveMatching (void) override = default;
+
+    /** Initialize matcher by preprocessing given SIFT/SURF features. */
+    void init (bundler::ViewportList* viewports) override;
+
+    /** Matches all feature types yielding a single matching result. */
+    void pairwise_match (int view_1_id, int view_2_id,
+        Matching::Result* result) const override;
+
+    /**
+     * Matches the N lowest resolution features and returns the number of
+     * matches. Can be used as a guess for full matchability. Useful values
+     * are at most 3 matches for 500 features, or 2 matches with 300 features.
+     */
+    int pairwise_match_lowres (int view_1_id, int view_2_id,
+        int num_features) const override;
+
+private:
+#if DISCRETIZE_DESCRIPTORS
+    typedef util::AlignedMemory<uint16_t, 16> SiftDescriptors;
+    typedef util::AlignedMemory<int16_t, 16> SurfDescriptors;
+#else
+    typedef util::AlignedMemory<float, 16> SiftDescriptors;
+    typedef util::AlignedMemory<float, 16> SurfDescriptors;
+#endif
+
+    /** Internal initialization methods for SIFT/SURF features. */
+    void init_sift (SiftDescriptors* dst, Sift::Descriptors const& src);
+    void init_surf (SurfDescriptors* dst, Surf::Descriptors const& src);
+
+    struct ProcessedFeatureSet
+    {
+        SiftDescriptors sift_descr;
+        int num_sift_descriptors;
+        SurfDescriptors surf_descr;
+        int num_surf_descriptors;
+    };
+    std::vector<ProcessedFeatureSet> processed_feature_sets;
+};
+
+SFM_NAMESPACE_END
+
+#endif /* SFM_EXHAUSTIVE_MATCHING_HEADER */
+

--- a/libs/sfm/feature_set.h
+++ b/libs/sfm/feature_set.h
@@ -16,11 +16,7 @@
 #include "util/aligned_memory.h"
 #include "sfm/sift.h"
 #include "sfm/surf.h"
-#include "sfm/matching.h"
 #include "sfm/defines.h"
-
-/* Whether to use floating point or 8-bit descriptors for matching. */
-#define DISCRETIZE_DESCRIPTORS 1
 
 SFM_NAMESPACE_BEGIN
 
@@ -47,18 +43,7 @@ public:
         FeatureTypes feature_types;
         Sift::Options sift_opts;
         Surf::Options surf_opts;
-        Matching::Options sift_matching_opts;
-        Matching::Options surf_matching_opts;
-        bool keep_descriptors;
     };
-
-#if DISCRETIZE_DESCRIPTORS
-    typedef util::AlignedMemory<unsigned short, 16> SiftDescriptor;
-    typedef util::AlignedMemory<signed short, 16> SurfDescriptor;
-#else
-    typedef util::AlignedMemory<float, 16> SiftDescriptor;
-    typedef util::AlignedMemory<float, 16> SurfDescriptor;
-#endif
 
 public:
     FeatureSet (void);
@@ -67,16 +52,6 @@ public:
 
     /** Computes the features specified in the options. */
     void compute_features (mve::ByteImage::Ptr image);
-
-    /** Matches all feature types yielding a single matching result. */
-    void match (FeatureSet const& other, Matching::Result* result) const;
-
-    /**
-     * Matches the N lowest resolution features and returns the number of
-     * matches. Can be used as a guess for full matchability. Useful values
-     * are at most 3 matches for 500 features, or 2 matches with 300 features.
-     */
-    int match_lowres (FeatureSet const& other, int num_features) const;
 
     /** Clear descriptor data. */
     void clear_descriptors (void);
@@ -99,10 +74,6 @@ private:
 
 private:
     Options opts;
-    int num_sift_descriptors;
-    int num_surf_descriptors;
-    SiftDescriptor sift_descr;
-    SurfDescriptor surf_descr;
 };
 
 /* ------------------------ Implementation ------------------------ */
@@ -110,26 +81,17 @@ private:
 inline
 FeatureSet::Options::Options (void)
     : feature_types(FEATURE_SIFT)
-    , keep_descriptors(false)
 {
-    this->sift_matching_opts.lowe_ratio_threshold = 0.8f;
-    this->sift_matching_opts.descriptor_length = 128;
-    this->surf_matching_opts.lowe_ratio_threshold = 0.7f;
-    this->surf_matching_opts.descriptor_length = 64;
 }
 
 inline
 FeatureSet::FeatureSet (void)
-    : num_sift_descriptors(0)
-    , num_surf_descriptors(0)
 {
 }
 
 inline
 FeatureSet::FeatureSet (Options const& options)
     : opts(options)
-    , num_sift_descriptors(0)
-    , num_surf_descriptors(0)
 {
 }
 

--- a/libs/sfm/matching.h
+++ b/libs/sfm/matching.h
@@ -27,8 +27,6 @@ public:
      */
     struct Options
     {
-        Options();
-
         /**
          * The length of the descriptor. Typically 128 for SIFT, 64 for SURF.
          */
@@ -103,14 +101,6 @@ public:
 };
 
 /* ---------------------------------------------------------------- */
-
-inline
-Matching::Options::Options (void)
-    : descriptor_length(128)
-    , lowe_ratio_threshold(0.8f)
-    , distance_threshold(std::numeric_limits<float>::max())
-{
-}
 
 template <typename T>
 void

--- a/libs/sfm/matching_base.h
+++ b/libs/sfm/matching_base.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2015, Simon Fuhrmann
+ * TU Darmstadt - Graphics, Capture and Massively Parallel Computing
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD 3-Clause license. See the LICENSE.txt file for details.
+ */
+
+#ifndef SFM_MATCHING_BASE_HEADER
+#define SFM_MATCHING_BASE_HEADER
+
+#include <limits>
+
+#include "sfm/bundler_common.h"
+#include "sfm/defines.h"
+#include "sfm/matching.h"
+#include "sfm/matching_base.h"
+
+SFM_NAMESPACE_BEGIN
+
+class MatchingBase
+{
+public:
+    struct Options
+    {
+        Matching::Options sift_matching_opts{ 128, 0.8f,
+            std::numeric_limits<float>::max() };
+        Matching::Options surf_matching_opts{ 64, 0.7f,
+            std::numeric_limits<float>::max() };
+    };
+
+    virtual ~MatchingBase (void) = default;
+
+    /**
+     * Initialize the matcher. This is used for preprocessing the features
+     * of the given viewports. For example, in the exhaustive matcher the
+     * features are discretized.
+     */
+    virtual void init (bundler::ViewportList* viewports) = 0;
+
+    /** Matches all feature types yielding a single matching result. */
+    virtual void pairwise_match (int view_1_id, int view_2_id,
+        Matching::Result* result) const = 0;
+
+    /**
+     * Matches the N lowest resolution features and returns the number of
+     * matches. Can be used as a guess for full matchability. Useful values
+     * are at most 3 matches for 500 features, or 2 matches with 300 features.
+     */
+    virtual int pairwise_match_lowres (int view_1_id, int view_2_id,
+        int num_features) const = 0;
+
+    Options opts;
+};
+
+SFM_NAMESPACE_END
+
+#endif /* SFM_MATCHING_BASE_HEADER */
+


### PR DESCRIPTION
- Move matching code from `FeatureSet` into its own class(es)
- Introduce `MatchingBase` class which consists of data structures (`Options`, `Result`), helper methods and an interface which are common to different matchers.
- Implement `ExhaustiveMatching` as the first matcher
- Add a pointer to `MatchingBase` in `sfm::bundler::Matching` to support different matchers in the future