### PR TITLE
SFM: Fix compilation of cascade hash matcher on Visual Studio

### DIFF
--- a/libs/sfm/cascade_hashing.h
+++ b/libs/sfm/cascade_hashing.h
@@ -14,7 +14,11 @@
 #include <iostream>
 #include <random>
 
-#include <popcntintrin.h>
+#ifdef _MSC_VER
+#   include <nmmintrin.h>
+#else
+#   include <popcntintrin.h>
+#endif
 
 #include "math/vector.h"
 #include "sfm/defines.h"


### PR DESCRIPTION
- popcntintrin.h is not provided by Visual Studio 2015 but nmmintrin.h
  includes _mm_popcnt_u64()