### PR TITLE
Refactor matrix/vector dimension(s)

### DIFF
--- a/libs/math/matrix.h
+++ b/libs/math/matrix.h
@@ -55,6 +55,9 @@ class Matrix
 public:
     typedef T ValueType;
 
+    static int constexpr rows = N;
+    static int constexpr cols = M;
+
     /* ------------------------ Constructors ---------------------- */
 
     /** Default ctor that leaves values uninitialized. */
@@ -75,10 +78,6 @@ public:
     /** Fills all vector elements with the given value. */
     Matrix<T,N,M>& fill (T const& value);
 
-    /** Returns the amount of rows of the matrix. */
-    int rows (void) const;
-    /** Returns the amount of columns of the matrix. */
-    int cols (void) const;
     /** Tests if the matrix is square. */
     bool is_square (void) const;
 
@@ -222,6 +221,12 @@ MATH_NAMESPACE_END
 MATH_NAMESPACE_BEGIN
 
 template <typename T, int N, int M>
+int constexpr Matrix<T,N,M>::rows;
+
+template <typename T, int N, int M>
+int constexpr Matrix<T,N,M>::cols;
+
+template <typename T, int N, int M>
 inline
 Matrix<T,N,M>::Matrix (void)
 {
@@ -276,8 +281,8 @@ template <typename T, int N>
 inline Matrix<T,N,N>&
 matrix_inplace_transpose (Matrix<T,N,N>& matrix)
 {
-    for (int i = 0; i < matrix.rows(); ++i)
-        for (int j = i + 1; j < matrix.cols(); ++j)
+    for (int i = 0; i < matrix.rows; ++i)
+        for (int j = i + 1; j < matrix.cols; ++j)
             std::swap(matrix(i, j), matrix(j, i));
     return matrix;
 }
@@ -290,20 +295,6 @@ Matrix<T,N,M>::fill (T const& value)
 {
     std::fill(m, m + N * M, value);
     return *this;
-}
-
-template <typename T, int N, int M>
-inline int
-Matrix<T,N,M>::rows (void) const
-{
-    return N;
-}
-
-template <typename T, int N, int M>
-inline int
-Matrix<T,N,M>::cols (void) const
-{
-    return M;
 }
 
 template <typename T, int N, int M>
@@ -472,8 +463,8 @@ Matrix<T,N,M>::mult (Matrix<T,M,U> const& rhs) const
 {
     typedef algo::InterleavedIter<T,U> RowIter;
     Matrix<T,N,U> ret;
-    for (int i = 0; i < ret.rows(); ++i)
-        for (int j = 0; j < ret.cols(); ++j)
+    for (int i = 0; i < ret.rows; ++i)
+        for (int j = 0; j < ret.cols; ++j)
             ret(i,j) = std::inner_product(m + M * i,
                 m + M * i + M, RowIter(*rhs + j), T(0));
     return ret;
@@ -737,9 +728,9 @@ template <typename T, int N, int M>
 inline std::ostream&
 operator<< (std::ostream& os, Matrix<T,N,M> const& m)
 {
-    for (int i = 0; i < m.rows(); ++i)
-        for (int j = 0; j < m.cols(); ++j)
-            os << m(i,j) << (j == m.cols() - 1 ? "\n" : " ");
+    for (int i = 0; i < m.rows; ++i)
+        for (int j = 0; j < m.cols; ++j)
+            os << m(i,j) << (j == m.cols - 1 ? "\n" : " ");
     return os;
 }
 

--- a/libs/math/vector.h
+++ b/libs/math/vector.h
@@ -82,6 +82,8 @@ class Vector
 public:
     typedef T ValueType;
 
+    static int constexpr dim = N;
+
     /* ------------------------ Constructors ---------------------- */
 
     /** Default ctor. */
@@ -117,9 +119,6 @@ public:
 
     /** Copies values from the given pointer. */
     Vector<T,N>& copy (T const* values, int num = N);
-
-    /** Returns the dimension of the vector. */
-    static int constexpr dim (void);
 
     /** Returns the smallest element in the vector. */
     T minimum (void) const;
@@ -275,6 +274,9 @@ MATH_NAMESPACE_END
 MATH_NAMESPACE_BEGIN
 
 template <typename T, int N>
+int constexpr Vector<T,N>::dim;
+
+template <typename T, int N>
 inline
 Vector<T,N>::Vector (void)
 {
@@ -382,13 +384,6 @@ Vector<T,N>::copy (T const* values, int num)
 {
     std::copy(values, values + num, this->v);
     return *this;
-}
-
-template <typename T, int N>
-inline int constexpr
-Vector<T,N>::dim (void)
-{
-    return N;
 }
 
 template <typename T, int N>

--- a/libs/sfm/cascade_hashing.h
+++ b/libs/sfm/cascade_hashing.h
@@ -237,7 +237,7 @@ void CascadeHashing::GlobalData::generate_proj_matrices (
     std::vector<T>* prim_hash, std::vector<std::vector<T>>* sec_hash,
     Options const& cashash_opts)
 {
-    int const dim_desc = T::dim();
+    int const dim_desc = T::dim;
     int const dim_hash_data = dim_desc;
 
     prim_hash->resize(dim_hash_data);
@@ -274,7 +274,7 @@ CascadeHashing::compute_cascade_hashes (std::vector<T> const& zero_mean_descs,
     std::vector<std::vector<T>> const& sec_proj_mats,
     Options const& cashash_opts)
 {
-    int const dim_desc = T::dim();
+    int const dim_desc = T::dim;
     int const dim_hash_data = dim_desc;
     uint8_t const dim_comp_hash_data = dim_hash_data / 64;
     uint8_t const num_bucket_bits = cashash_opts.num_bucket_bits;
@@ -356,7 +356,7 @@ CascadeHashing::oneway_match (Matching::Options const& matching_opts,
 
     uint16_t const min_num_candidates = cashash_opts.min_num_candidates;
     uint16_t const max_num_candidates = cashash_opts.max_num_candidates;
-    int const descriptor_length = V::dim();
+    int const descriptor_length = V::dim;
     uint8_t const dim_hash_data = descriptor_length;
     uint32_t const dim_comp_hash_data = dim_hash_data / 64;
 

--- a/tests/math/gtest_matrix.cc
+++ b/tests/math/gtest_matrix.cc
@@ -80,6 +80,8 @@ TEST(MatrixTest, MatrixOperations)
     test(2,0) = 7.0f; test(2,1) = 8.0f; test(2,2) = 9.0f;
 
     /* Matrix access, min, max, square check, . */
+    EXPECT_EQ((Matrix<int,3,4>::rows), 3);
+    EXPECT_EQ((Matrix<int,3,4>::cols), 4);
     EXPECT_EQ(test.col(1), Vec3f(2.0f, 5.0f, 8.0f));
     EXPECT_EQ(test.row(1), Vec3f(4.0f, 5.0f, 6.0f));
     EXPECT_EQ(Matrix3f(1.0f).minimum(), 1.0f);

--- a/tests/math/gtest_vector.cc
+++ b/tests/math/gtest_vector.cc
@@ -16,9 +16,9 @@ TEST(VectorTest, MiscOperations)
     EXPECT_EQ(Vec2f(10.0f, 0.0f).normalize(), Vec2f(1.0f, 0.0f));
     EXPECT_EQ(Vec2f(3.0f, 4.0f).norm(), 5.0f);
     EXPECT_EQ(Vec2f(2.0f, 2.0f).square_norm(), 8.0f);
-    EXPECT_EQ(Vec2f().dim(), 2);
-    EXPECT_EQ(Vec3f().dim(), 3);
-    EXPECT_EQ(Vec4f().dim(), 4);
+    EXPECT_EQ(Vec2f::dim, 2);
+    EXPECT_EQ(Vec3f::dim, 3);
+    EXPECT_EQ(Vec4f::dim, 4);
     EXPECT_EQ(Vec2f(-1.0f, 2.0f).abs_value(), Vec2f(1.0f, 2.0f));
     EXPECT_EQ(Vec2f(-1.0f, -2.0f).abs_value(), Vec2f(1.0f, 2.0f));
     EXPECT_EQ(Vec2f(1.0f, -2.0f).abs_value(), Vec2f(1.0f, 2.0f));


### PR DESCRIPTION
- Querying the dimension of a vector or the number of rows/columns of a
  matrix is now done by accessing (a) static const variable(s) instead of
  calling a method.
- The refactoring of the vector class also works around a compiler bug related
  to the constexpr keyword in Visual Studio 2015 Update 1.