### PR TITLE
Output of Visitibility Information & High Resolution Photosynther Images Import

### DIFF
--- a/apps/dmrecon/dmrecon.cc
+++ b/apps/dmrecon/dmrecon.cc
@@ -155,6 +155,8 @@ main (int argc, char** argv)
         "progress output style: 'silent', 'simple' or 'fancy'");
     args.add_option('\0', "force", false,
         "Reconstruct and overwrite existing depthmaps");
+	args.add_option('V', "keep-views", false,
+		"save (per depth map pixel) view indices of views which were used to create depth map pixel values (save local view selections)");
     args.parse(argc, argv);
 
     AppSettings conf;
@@ -210,8 +212,10 @@ main (int argc, char** argv)
             }
 
         }
-        else if (arg->opt->lopt == "force")
-            conf.force_recon = true;
+		else if (arg->opt->lopt == "force")
+			conf.force_recon = true;
+		else if (arg->opt->lopt == "keep-views")
+			conf.mvs.keepViewIndicesPerPixel = true;
         else
         {
             args.generate_helptext(std::cerr);

--- a/apps/makescene/makescene.cc
+++ b/apps/makescene/makescene.cc
@@ -658,14 +658,21 @@ import_bundle (AppSettings const& conf)
         else if (bundler_fmt == BUNDLE_FORMAT_PHOTOSYNTHER)
         {
             /*
-             * Depending on the version, try to load two file names:
+			 * Depending on the version and availability of images in original resolution,
+				try to load three file names:
+			 * New version, level 0 = original size: l0/imgyyyy.jpg
              * New version: forStereo_xxxx_yyyy.png
              * Old version: undistorted_xxxx_yyyy.jpg
              */
+			std::string undist_filename
+				= util::fs::join_path(undist_path, "l0/img"
+				+ util::string::get_filled(num_valid_cams, 4) + ".jpg");
+
             std::string undist_new_filename
                 = util::fs::join_path(undist_path, "forStereo_"
                 + util::string::get_filled(conf.bundle_id, 4) + "_"
                 + util::string::get_filled(num_valid_cams, 4) + ".png");
+
             std::string undist_old_filename
                 = util::fs::join_path(undist_path, "undistorted_"
                 + util::string::get_filled(conf.bundle_id, 4) + "_"
@@ -674,7 +681,9 @@ import_bundle (AppSettings const& conf)
             /* Try the newer file name and fall back if not existing. */
             try
             {
-                if (util::fs::file_exists(undist_new_filename.c_str()))
+				if (util::fs::file_exists(undist_filename.c_str()))
+					undist = mve::image::load_file(undist_filename);
+				else if (util::fs::file_exists(undist_new_filename.c_str()))
                     undist = mve::image::load_file(undist_new_filename);
                 else
                     undist = mve::image::load_file(undist_old_filename);

--- a/apps/scene2pset/scene2pset.cc
+++ b/apps/scene2pset/scene2pset.cc
@@ -253,7 +253,7 @@ main (int argc, char** argv)
         /* Triangulate depth map. */
         mve::CameraInfo const& cam = view->get_camera();
         mve::TriangleMesh::Ptr mesh;
-		mesh = mve::geom::depthmap_triangulate(dm, ci, vi, cam);
+		mesh = mve::geom::depthmap_triangulate(dm, ci, cam, vi);
         mve::TriangleMesh::VertexList const& mverts(mesh->get_vertices());
         mve::TriangleMesh::NormalList const& mnorms(mesh->get_vertex_normals());
         mve::TriangleMesh::ColorList const& mvcol(mesh->get_vertex_colors());

--- a/apps/scene2pset/scene2pset.cc
+++ b/apps/scene2pset/scene2pset.cc
@@ -35,7 +35,7 @@ struct AppSettings
     std::string outmesh;
     std::string dmname = "depth-L0";
     std::string image = "undistorted";
-	std::string vmname = "views-L0";
+	std::string vmname;
     std::string mask;
 	std::string aabb;
 

--- a/apps/scene2pset/scene2pset.cc
+++ b/apps/scene2pset/scene2pset.cc
@@ -102,8 +102,8 @@ main (int argc, char** argv)
 	args.add_option('c', "with-conf", false, "Write points with confidence (PLY only)");
 	args.add_option('n', "with-normals", false, "Write points with normals (PLY only)");
 	args.add_option('s', "with-scale", false, "Write points with scale values (PLY only)");
-	args.add_option('V', "viewmap", false,
-		"Name of views image to write points with view indices of views which were used to create them (PLY only)");
+	args.add_option('V', "viewmap", true,
+		"Name of views image to write points with view indices of views which were used to create them (PLY only) [views-L0]");
     args.add_option('m', "mask", true, "Name of mask/silhouette image to clip 3D points []");
     args.add_option('v', "views", true, "View IDs to use for reconstruction [all]");
     args.add_option('b', "bounding-box", true, "Six comma separated values used as AABB.");

--- a/apps/umve/scene_addins/addin_dm_triangulate.cc
+++ b/apps/umve/scene_addins/addin_dm_triangulate.cc
@@ -62,8 +62,8 @@ AddinDMTriangulate::on_triangulate_clicked (void)
 
     float dd_factor = this->dm_depth_disc->value();
     std::string embedding = this->dm_depthmap_cb->currentText().toStdString();
-    std::string colorimage = this->dm_colorimage_cb->currentText().toStdString();
-    if (embedding.empty() || colorimage.empty())
+	std::string color_image = this->dm_colorimage_cb->currentText().toStdString();
+	if (embedding.empty() || color_image.empty())
     {
         this->show_error_box("Error triangulating", "No embedding selected");
         return;
@@ -84,14 +84,16 @@ AddinDMTriangulate::on_triangulate_clicked (void)
             "Depthmap not available: " + embedding);
         return;
     }
-    mve::ByteImage::Ptr ci(view->get_byte_image(colorimage));
-    mve::CameraInfo const& cam(view->get_camera());
+	mve::ByteImage::Ptr ci(view->get_byte_image(color_image));
+	mve::CameraInfo const& cam(view->get_camera());
 
     /* Triangulate mesh. */
     util::WallTimer timer;
     mve::TriangleMesh::Ptr mesh;
     try
-    { mesh = mve::geom::depthmap_triangulate(dm, ci, cam, dd_factor); }
+	{
+		mesh = mve::geom::depthmap_triangulate(dm, ci, cam, nullptr, dd_factor);
+	}
     catch (std::exception& e)
     {
         this->show_error_box("Error triangulating", e.what());

--- a/apps/umve/viewinspect/tonemapping.cc
+++ b/apps/umve/viewinspect/tonemapping.cc
@@ -534,9 +534,6 @@ ToneMapping::set_image (mve::ImageBase::ConstPtr img)
 mve::ByteImage::ConstPtr
 ToneMapping::render (void)
 {
-    if (this->image->get_type() == mve::IMAGE_TYPE_UINT8)
-        return std::dynamic_pointer_cast<mve::ByteImage const>(this->image);
-
     //util::WallTimer timer;
     //std::cout << "Rendering..." << std::flush;
     int const width = this->image->width();

--- a/apps/umve/viewinspect/viewinspect.cc
+++ b/apps/umve/viewinspect/viewinspect.cc
@@ -483,12 +483,26 @@ ViewInspect::populate_embeddings (void)
     if (this->view == nullptr)
         return;
 
+	/* Get image proxies of current view. */
     std::vector<std::string> names;
     mve::View::ImageProxies const& proxies = this->view->get_images();
     for (std::size_t i = 0; i < proxies.size(); ++i)
-        names.push_back(proxies[i].name);
+	{
+		mve::View::ImageProxy const& proxy = proxies[i];
+
+		/* Only add images which can be displayed. */
+		if (proxy.type != mve::IMAGE_TYPE_FLOAT &&
+			proxy.type != mve::IMAGE_TYPE_DOUBLE &&
+			proxy.type != mve::IMAGE_TYPE_UINT8)
+		{
+			continue;
+		}
+
+		names.push_back(proxy.name);
+	}
     std::sort(names.begin(), names.end());
 
+	/* Add supported images to displayed embeddings list. */
     for (std::size_t i = 0; i < names.size(); ++i)
     {
         this->embeddings->addItem(QString(names[i].c_str()), (int)i);

--- a/apps/umve/viewinspect/viewinspect.h
+++ b/apps/umve/viewinspect/viewinspect.h
@@ -73,7 +73,7 @@ private slots:
     void on_view_reload (void);
     void on_reload_embeddings (void);
     void on_image_clicked (int x, int y, QMouseEvent* event);
-    void on_tone_mapping_changed (void);
+	void on_image_changed (void);
 
     void on_scene_selected (mve::Scene::Ptr scene);
     void on_view_selected (mve::View::Ptr view);

--- a/libs/dmrecon/settings.h
+++ b/libs/dmrecon/settings.h
@@ -39,6 +39,7 @@ struct Settings
     int scale = 0;
     bool useColorScale = true;
     bool writePlyFile = false;
+	bool keepViewIndicesPerPixel = false;
 
     /** Features outside the AABB are ignored. */
     math::Vec3f aabbMin = math::Vec3f(-std::numeric_limits<float>::max());

--- a/libs/dmrecon/single_view.cc
+++ b/libs/dmrecon/single_view.cc
@@ -65,7 +65,7 @@ SingleView::loadColorImage(int _minLevel)
 }
 
 void
-SingleView::prepareMasterView(int scale)
+SingleView::prepareMasterView(int scale, bool keepViewIndicesPerPixel, int nrViewIndicesPerPixel)
 {
     /* Prepare target level (view is the master view). */
     this->target_level = (*this->img_pyramid)[scale];
@@ -79,6 +79,12 @@ SingleView::prepareMasterView(int scale)
     this->normalImg = mve::FloatImage::create(scaled_width, scaled_height, 3);
     this->dzImg = mve::FloatImage::create(scaled_width, scaled_height, 2);
     this->confImg = mve::FloatImage::create(scaled_width, scaled_height, 1);
+
+	if (keepViewIndicesPerPixel)
+	{
+		this->viewIndicesImg = mve::IntImage::create(scaled_width, scaled_height, nrViewIndicesPerPixel);
+		this->viewIndicesImg->fill(-1);	//initial value with meaning: no camera
+	}
 }
 
 math::Vec3f

--- a/libs/dmrecon/single_view.h
+++ b/libs/dmrecon/single_view.h
@@ -53,7 +53,7 @@ public:
     bool pointInFrustum(math::Vec3f const& wp) const;
     void saveReconAsPly(std::string const& path, float scale) const;
     bool seesFeature(std::size_t idx) const;
-    void prepareMasterView(int scale);
+	void prepareMasterView(int scale, bool keepViewIndicesPerPixel, int nrViewIndicesPerPixel);
     math::Vec2f worldToScreen(math::Vec3f const& point, int level);
     math::Vec2f worldToScreenScaled(math::Vec3f const& point);
     std::size_t getViewID() const;
@@ -64,6 +64,8 @@ public:
     mve::FloatImage::Ptr normalImg;
     mve::FloatImage::Ptr dzImg;
     mve::FloatImage::Ptr confImg;
+	mve::IntImage::Ptr viewIndicesImg;
+	
 
 private:
     /** Constructor is private, use the create() method for instantiation. */

--- a/libs/mve/bundle_io.cc
+++ b/libs/mve/bundle_io.cc
@@ -306,7 +306,7 @@ load_bundler_ps_intern (std::string const& filename, BundleFormat format)
     if (in.eof())
         throw util::Exception("Unexpected EOF in bundle file");
 
-    if (num_views < 0 || num_views > 10000
+	if (num_views < 0 || num_views >= 10000
         || num_features < 0 || num_features > 100000000)
         throw util::Exception("Spurious amount of cameras or features");
 

--- a/libs/mve/camera_io.cc
+++ b/libs/mve/camera_io.cc
@@ -32,7 +32,7 @@ save_camera_infos (const std::vector<View::Ptr> &views, std::string const& file_
 		throw util::FileException(file_name, std::strerror(errno));
 
 	out << "MVE camera infos 1.0\n";
-	out << "view_count = " << view_count << "\n";
+	out << "camera_count = " << view_count << "\n";
 
 	/* Write all cameras infos to file. */
 	for (size_t viewIdx = 0; viewIdx < view_count; ++viewIdx)

--- a/libs/mve/camera_io.cc
+++ b/libs/mve/camera_io.cc
@@ -32,7 +32,7 @@ save_camera_infos (const std::vector<View::Ptr> &views, std::string const& file_
 		throw util::FileException(file_name, std::strerror(errno));
 
 	out << "MVE camera infos 1.0\n";
-	out << "view_count = " << view_count << "\n\n";
+	out << "view_count = " << view_count << "\n";
 
 	/* Write all cameras infos to file. */
 	for (size_t viewIdx = 0; viewIdx < view_count; ++viewIdx)

--- a/libs/mve/camera_io.cc
+++ b/libs/mve/camera_io.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2016, Samir Aroudj
+ * TU Darmstadt - Graphics, Capture and Massively Parallel Computing
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD 3-Clause license. See the LICENSE.txt file for details.
+ */
+
+#include <cerrno>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <fstream>
+#include "mve/camera_io.h"
+#include "util/file_system.h"
+#include "util/string.h"
+#include "util/exception.h"
+
+MVE_NAMESPACE_BEGIN
+
+/* ---------------------------------------------------------------- */
+
+void
+save_camera_infos (const std::vector<View::Ptr> &views, std::string const& file_name)
+{
+	const size_t view_count = views.size();
+	std::cout << "Writing camera infos of (" << view_count << " cameras: " << file_name << "...\n";
+
+	std::ofstream out(file_name.c_str(), std::ios::binary);
+	if (!out.good())
+		throw util::FileException(file_name, std::strerror(errno));
+
+	out << "MVE camera infos 1.0\n";
+	out << "view_count = " << view_count << "\n\n";
+
+	/* Write all cameras infos to file. */
+	for (size_t viewIdx = 0; viewIdx < view_count; ++viewIdx)
+	{
+		if (nullptr == views[viewIdx])
+			continue;
+
+		View const& view = *(views[viewIdx]);
+		CameraInfo const& cam = view.get_camera();
+
+		/* identifiers */
+		out << "id = " << view.get_id() << "\n";
+		out << "name = " << view.get_name() << "\n";
+
+		/* intrinsics */
+		out << "focal_length = " << cam.flen << "\n";
+		out << "principle_point = " << cam.ppoint[0] << " " << cam.ppoint[1] << "\n";
+		out << "pixel_aspect_ratio = " << cam.paspect << "\n";
+		out << "camera_distortion = " << cam.dist[0] << " " << cam.dist[1] << "\n";
+
+		/* extrinsics */
+		out << "translation = " << cam.trans[0] << " " << cam.trans[1] << " " << cam.trans[2] << "\n";
+		out << "rotation = ";
+		out	<< cam.rot[0] << " " << cam.rot[1] << " " << cam.rot[2] << " ";
+		out	<< cam.rot[3] << " " << cam.rot[4] << " " << cam.rot[5] << " ";
+		out	<< cam.rot[6] << " " << cam.rot[7] << " " << cam.rot[8] << "\n";
+	}
+}
+
+/* ---------------------------------------------------------------- */
+
+MVE_NAMESPACE_END
+

--- a/libs/mve/camera_io.h
+++ b/libs/mve/camera_io.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2016, Samir Aroudj
+ * TU Darmstadt - Graphics, Capture and Massively Parallel Computing
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD 3-Clause license. See the LICENSE.txt file for details.
+ */
+
+#ifndef MVE_CAMERA_IO_HEADER
+#define MVE_CAMERA_IO_HEADER
+
+#include "mve/view.h"
+
+MVE_NAMESPACE_BEGIN
+
+/* ------------------- MVE native camera info format ------------------- */
+
+/** Saves camera info of each view in the provided list to file_name. */
+void
+save_camera_infos (std::vector<View::Ptr> const& views, std::string const& file_name);
+
+
+MVE_NAMESPACE_END
+
+#endif /* MVE_CAMERA_IO_HEADER */
+

--- a/libs/mve/depthmap.cc
+++ b/libs/mve/depthmap.cc
@@ -319,8 +319,8 @@ depthmap_triangulate (FloatImage::ConstPtr dm, math::Matrix3f const& invproj,
 
 /* ---------------------------------------------------------------- */
 TriangleMesh::Ptr
-depthmap_triangulate(FloatImage::ConstPtr dm, ByteImage::ConstPtr ci, IntImage::ConstPtr vi,
-    math::Matrix3f const& invproj, float dd_factor)
+depthmap_triangulate(FloatImage::ConstPtr dm, ByteImage::ConstPtr ci,
+	math::Matrix3f const& invproj, IntImage::ConstPtr vi, float dd_factor)
 {
     if (dm == nullptr)
         throw std::invalid_argument("Null depthmap given");
@@ -395,8 +395,8 @@ depthmap_triangulate(FloatImage::ConstPtr dm, ByteImage::ConstPtr ci, IntImage::
 /* ---------------------------------------------------------------- */
 
 TriangleMesh::Ptr
-depthmap_triangulate (FloatImage::ConstPtr dm, ByteImage::ConstPtr ci, IntImage::ConstPtr vi,
-    CameraInfo const& cam, float dd_factor)
+depthmap_triangulate (FloatImage::ConstPtr dm, ByteImage::ConstPtr ci,
+	CameraInfo const& cam, IntImage::ConstPtr vi, float dd_factor)
 {
     if (dm == nullptr)
         throw std::invalid_argument("Null depthmap given");
@@ -407,7 +407,7 @@ depthmap_triangulate (FloatImage::ConstPtr dm, ByteImage::ConstPtr ci, IntImage:
     math::Matrix3f invproj;
     cam.fill_inverse_calibration(*invproj, dm->width(), dm->height());
     mve::TriangleMesh::Ptr mesh;
-	mesh = mve::geom::depthmap_triangulate(dm, ci, vi, invproj, dd_factor);
+	mesh = mve::geom::depthmap_triangulate(dm, ci, invproj, vi, dd_factor);
 
     /* Transform mesh to world coordinates. */
     math::Matrix4f ctw;

--- a/libs/mve/depthmap.h
+++ b/libs/mve/depthmap.h
@@ -111,7 +111,7 @@ depthmap_triangulate (FloatImage::ConstPtr dm, math::Matrix3f const& invproj,
  * image coordinates.
  */
 TriangleMesh::Ptr
-depthmap_triangulate (FloatImage::ConstPtr dm, ByteImage::ConstPtr ci,
+depthmap_triangulate (FloatImage::ConstPtr dm, ByteImage::ConstPtr ci, IntImage::ConstPtr vi,
     math::Matrix3f const& invproj, float dd_factor = 5.0f);
 
 /**
@@ -120,7 +120,7 @@ depthmap_triangulate (FloatImage::ConstPtr dm, ByteImage::ConstPtr ci,
  * the mesh into the global coordinate system.
  */
 TriangleMesh::Ptr
-depthmap_triangulate (FloatImage::ConstPtr dm, ByteImage::ConstPtr ci,
+depthmap_triangulate (FloatImage::ConstPtr dm, ByteImage::ConstPtr ci, IntImage::ConstPtr vi,
     CameraInfo const& cam, float dd_factor = 5.0f);
 
 /**

--- a/libs/mve/depthmap.h
+++ b/libs/mve/depthmap.h
@@ -111,8 +111,8 @@ depthmap_triangulate (FloatImage::ConstPtr dm, math::Matrix3f const& invproj,
  * image coordinates.
  */
 TriangleMesh::Ptr
-depthmap_triangulate (FloatImage::ConstPtr dm, ByteImage::ConstPtr ci, IntImage::ConstPtr vi,
-    math::Matrix3f const& invproj, float dd_factor = 5.0f);
+depthmap_triangulate (FloatImage::ConstPtr dm, ByteImage::ConstPtr ci,
+	math::Matrix3f const& invproj, IntImage::ConstPtr vi = nullptr, float dd_factor = 5.0f);
 
 /**
  * A helper function that triangulates the given depth map with optional
@@ -120,8 +120,8 @@ depthmap_triangulate (FloatImage::ConstPtr dm, ByteImage::ConstPtr ci, IntImage:
  * the mesh into the global coordinate system.
  */
 TriangleMesh::Ptr
-depthmap_triangulate (FloatImage::ConstPtr dm, ByteImage::ConstPtr ci, IntImage::ConstPtr vi,
-    CameraInfo const& cam, float dd_factor = 5.0f);
+depthmap_triangulate (FloatImage::ConstPtr dm, ByteImage::ConstPtr ci,
+	CameraInfo const& cam, IntImage::ConstPtr vi = nullptr, float dd_factor = 5.0f);
 
 /**
  * Algorithm to triangulate range grids.

--- a/libs/mve/mesh.cc
+++ b/libs/mve/mesh.cc
@@ -190,6 +190,8 @@ TriangleMesh::delete_vertices (DeleteList const& delete_list)
         math::algo::vector_clean(delete_list, &this->vertex_values);
     if (this->has_vertex_texcoords())
         math::algo::vector_clean(delete_list, &this->vertex_texcoords);
+	if (this->has_vertex_view_lists())
+		math::algo::vector_clean(delete_list, &this->vertex_view_lists);
     math::algo::vector_clean(delete_list, &this->vertices);
 }
 

--- a/libs/mve/mesh.h
+++ b/libs/mve/mesh.h
@@ -95,6 +95,7 @@ public:
     typedef std::vector<math::Vec3f> NormalList;
     typedef std::vector<math::Vec2f> TexCoordList;
     typedef std::vector<VertexID> FaceList;
+	typedef std::vector<std::vector<int>> VertexViewLists;
 
     typedef std::vector<bool> DeleteList;
 
@@ -130,6 +131,13 @@ public:
     /** Returns the face colors. */
     ColorList& get_face_colors (void);
 
+	/** Returns a list of view sets that provides a set of views for each vertex.
+		The views in a set for a single vertex were used to estimate the vertex values and thus should see this vertex.*/
+	VertexViewLists const& get_vertex_view_lists(void) const;
+	/** Returns a list of view sets that provides a set of views for each vertex.
+		The views in a set for a single vertex were used to estimate the vertex values and thus should see this vertex.*/
+	VertexViewLists& get_vertex_view_lists(void);
+
     /** Returns true if vertex normal amount equals vertex amount. */
     bool has_vertex_normals (void) const;
     /** Returns true if texture coordinate amount equals vertex amount. */
@@ -138,6 +146,8 @@ public:
     bool has_face_normals (void) const;
     /** Returns true if face color amount equals face amount. */
     bool has_face_colors (void) const;
+	/** Returns true if the number of view sets in vertex_view_lists equals the number of vertices. */
+	bool has_vertex_view_lists(void) const;
 
     /** Recalculates normals if normal amount is inconsistent. */
     void ensure_normals (bool face = true, bool vertex = true);
@@ -177,6 +187,7 @@ protected:
     FaceList faces;
     NormalList face_normals;
     ColorList face_colors;
+	VertexViewLists vertex_view_lists;
 
 protected:
     /** Use the create() methods to instantiate a mesh. */
@@ -363,6 +374,18 @@ TriangleMesh::get_face_colors (void) const
     return this->face_colors;
 }
 
+inline TriangleMesh::VertexViewLists&
+TriangleMesh::get_vertex_view_lists(void)
+{
+	return this->vertex_view_lists;
+}
+
+inline TriangleMesh::VertexViewLists const&
+TriangleMesh::get_vertex_view_lists(void) const
+{
+	return this->vertex_view_lists;
+}
+
 inline void
 TriangleMesh::clear_normals (void)
 {
@@ -407,6 +430,13 @@ TriangleMesh::has_face_colors (void) const
 {
     return !this->faces.empty()
         && this->faces.size() == this->face_colors.size() * 3;
+}
+
+inline bool
+TriangleMesh::has_vertex_view_lists(void) const
+{
+	return !this->vertices.empty()
+		&& this->vertex_view_lists.size() == this->vertices.size();
 }
 
 MVE_NAMESPACE_END

--- a/libs/mve/mesh_io_ply.cc
+++ b/libs/mve/mesh_io_ply.cc
@@ -305,8 +305,15 @@ load_ply_mesh (std::string const& filename)
                 }
                 else if (header[1] == "int")
                 {
+					if (std::string::npos != header[2].find("viewID"))
+					{
+						v_format.push_back(PLY_V_VIEW_ID);
+					}
                     /* Ignore int data types. */
-                    v_format.push_back(PLY_V_IGNORE_UINT32);
+					else
+					{
+						v_format.push_back(PLY_V_IGNORE_UINT32);
+					}
                 }
                 else
                 {
@@ -375,10 +382,12 @@ load_ply_mesh (std::string const& filename)
     TriangleMesh::ValueList& vvalues = mesh->get_vertex_values();
     TriangleMesh::TexCoordList& tcoords = mesh->get_vertex_texcoords();
     TriangleMesh::NormalList& vnormals = mesh->get_vertex_normals();
+	TriangleMesh::VertexViewLists& vviews = mesh->get_vertex_view_lists();
 
     bool want_colors = false;
     bool want_vnormals = false;
     bool want_tex_coords = false;
+	bool want_views = false;
 
     for (std::size_t i = 0; i < v_format.size(); ++i)
     {
@@ -404,6 +413,10 @@ load_ply_mesh (std::string const& filename)
                 want_tex_coords = true;
                 break;
 
+			case PLY_V_VIEW_ID:
+				want_views = true;
+				break;
+
             default:
                 break;
         }
@@ -425,6 +438,8 @@ load_ply_mesh (std::string const& filename)
         vcolors.reserve(num_vertices);
     if (want_vnormals)
         vnormals.reserve(num_vertices);
+	if (want_views)
+		vviews.resize(num_vertices);
 
     bool eof = false;
     for (std::size_t i = 0; !eof && i < num_vertices; ++i)
@@ -433,6 +448,7 @@ load_ply_mesh (std::string const& filename)
         math::Vec3f vnormal(0.0f, 0.0f, 0.0f);
         math::Vec4f color(1.0f, 0.5f, 0.5f, 1.0f); // Make it ugly by default
         math::Vec2f tex_coord(0.0f, 0.0f);
+		int view_index = -1;
 
         for (std::size_t n = 0; n < v_format.size(); ++n)
         {
@@ -505,6 +521,10 @@ load_ply_mesh (std::string const& filename)
                 ply_read_value<unsigned char>(input, ply_format);
                 break;
 
+			case PLY_V_VIEW_ID:
+				view_index = ply_read_value<int>(input, ply_format);
+				break;
+
             default:
                 throw std::runtime_error("Unhandled PLY vertex property");
             }
@@ -517,6 +537,9 @@ load_ply_mesh (std::string const& filename)
             vcolors.push_back(color);
         if (want_tex_coords)
             tcoords.push_back(tex_coord);
+		if (want_views)
+			if (view_index >= 0)
+				vviews[i].push_back(view_index);
 
         eof = input.eof();
     }
@@ -776,10 +799,8 @@ save_ply_mesh (TriangleMesh::ConstPtr mesh, std::string const& filename,
 
 	if (write_vview_ids)
 	{
-		for (std::size_t channel = 0; channel < options.view_ids_per_vertex; ++channel)
-		{
-			out << "property int viewID" << channel << std::endl;
-		}
+		for (std::size_t i = 0; i < options.view_ids_per_vertex; ++i)
+			out << "property int viewID" << i << std::endl;
 	}
 
     if (face_amount)

--- a/libs/mve/mesh_io_ply.h
+++ b/libs/mve/mesh_io_ply.h
@@ -54,9 +54,11 @@ struct SavePLYOptions
     bool write_vertex_normals = false;
     bool write_vertex_confidences = true;
     bool write_vertex_values = true;
+	bool write_vertex_view_ids = false;
     bool write_face_colors = true;
     bool write_face_normals = false;
     unsigned int verts_per_simplex = 3;
+	unsigned char view_ids_per_vertex = 4;
 };
 
 /**

--- a/libs/mve/mesh_io_ply.h
+++ b/libs/mve/mesh_io_ply.h
@@ -139,10 +139,11 @@ enum PLYVertexProperty
     PLY_V_FLOAT_V,
     PLY_V_FLOAT_CONF,
     PLY_V_FLOAT_VALUE,
+	PLY_V_VIEW_ID,
     PLY_V_IGNORE_FLOAT,
     PLY_V_IGNORE_DOUBLE,
     PLY_V_IGNORE_UINT32,
-    PLY_V_IGNORE_UINT8
+	PLY_V_IGNORE_UINT8,
 };
 
 /** PLY face element properties. */

--- a/libs/mve/scene.cc
+++ b/libs/mve/scene.cc
@@ -15,6 +15,7 @@
 #include "util/file_system.h"
 #include "mve/scene.h"
 #include "mve/bundle_io.h"
+#include "mve/camera_io.h"
 
 MVE_NAMESPACE_BEGIN
 
@@ -53,11 +54,15 @@ Scene::save_bundle (void)
 void
 Scene::save_views (void)
 {
+	std::cout << "Saving camera infos to camera MVE file..." << std::flush;
+		save_camera_infos(this->views, "camera_infos.txt");
+	std::cout << " done." << std::endl;
+
     std::cout << "Saving views to MVE files..." << std::flush;
     for (std::size_t i = 0; i < this->views.size(); ++i)
         if (this->views[i] != nullptr && this->views[i]->is_dirty())
             this->views[i]->save_view();
-    std::cout << " done." << std::endl;
+	std::cout << " done." << std::endl;
 }
 
 /* ---------------------------------------------------------------- */

--- a/libs/mve/scene.cc
+++ b/libs/mve/scene.cc
@@ -54,8 +54,10 @@ Scene::save_bundle (void)
 void
 Scene::save_views (void)
 {
+	std::string cameraFile = basedir + "/cameras.txt";
+
 	std::cout << "Saving camera infos to camera MVE file..." << std::flush;
-		save_camera_infos(this->views, "camera_infos.txt");
+		save_camera_infos(this->views, cameraFile);
 	std::cout << " done." << std::endl;
 
     std::cout << "Saving views to MVE files..." << std::flush;

--- a/libs/mve/view.h
+++ b/libs/mve/view.h
@@ -221,6 +221,9 @@ public:
     /** Returns an image of type IMAGE_TYPE_FLOAT. */
     FloatImage::Ptr get_float_image (std::string const& name);
 
+	/** Returns an image of type IMAGE_TYPE_SINT32 (int). */
+	IntImage::Ptr get_int_image(std::string const& name);
+
     /**
      * Sets an image to the view and marks it dirty.
      * If an image by that name already exists, it is overwritten.
@@ -409,6 +412,13 @@ View::get_float_image (std::string const& name)
 {
     return std::dynamic_pointer_cast<FloatImage>
         (this->get_image(name, IMAGE_TYPE_FLOAT));
+}
+
+inline IntImage::Ptr
+View::get_int_image(std::string const& name)
+{
+	return std::dynamic_pointer_cast<IntImage>
+		(this->get_image(name, IMAGE_TYPE_SINT32));
 }
 
 MVE_NAMESPACE_END


### PR DESCRIPTION
Additional visibility information output:
- dmrecon: output of images with view IDs from local view selection for reconstructed depth values if wanted
- ply_mesh
- scene2pset: output of view IDs as vertex element properties if wanted
- mesh_io_ply.cc: support of view ID vertex element properties for loading
- umve: hide view ID images as it doesn't make sense to show them
- scene.cc: if scene is saved cameras.txt file is created (contains positions etc. of all cameras)

Changes for photosynther:
- makescene: usage of images from l0 folder to import high resolution undistorted images into the scene instead of downscaled for_stereo... images if available