### PR TITLE
FSSR: Compute node center incrementally in Octree::influence_query()

### DIFF
--- a/libs/fssr/octree.h
+++ b/libs/fssr/octree.h
@@ -184,7 +184,8 @@ private:
     void get_samples_per_level (std::vector<std::size_t>* stats,
         Node const* node, std::size_t level) const;
     void influence_query (math::Vec3d const& pos, double factor,
-        std::vector<Sample const*>* result, Iterator const& iter) const;
+        std::vector<Sample const*>* result, Iterator const& iter,
+        math::Vec3d const& parent_node_center) const;
     void limit_octree_level (Node* node, Node* parent, int level);
 
 private:
@@ -310,7 +311,8 @@ Octree::influence_query (math::Vec3d const& pos, double factor,
     std::vector<Sample const*>* result) const
 {
     result->resize(0);
-    this->influence_query(pos, factor, result, this->get_iterator_for_root());
+    this->influence_query(pos, factor, result, this->get_iterator_for_root(),
+        this->root_center);
 }
 
 inline void


### PR DESCRIPTION
Speed-up over Octree::node_center_and_size() on citywall-20140923 (L2) dataset:
1x Intel Core i7-3930K (6 cores, 12 threads)     : ~1.43x (~7086.1s -> ~4962.4s)
2x Intel Xeon E5-2687W v3 (2x8 cores, 32 threads): ~1.41x (~3099.0s -> ~2197.6s)

Speed-up over Octree::node_center_and_size() on achteck_turm-20130528 (L2) dataset:
1x Intel Core i7-3930K (6 cores, 12 threads)     : ~2.06x (~1452.2s -> ~705.3s)
2x Intel Xeon E5-2687W v3 (2x8 cores, 32 threads): ~1.89x (~ 644.8s -> ~341.7s)