### PR TITLE
Fix Clang compile error

### DIFF
--- a/apps/umve/viewinspect/imageoperations.cc
+++ b/apps/umve/viewinspect/imageoperations.cc
@@ -36,7 +36,7 @@ ImageOperationsWidget::ImageOperationsWidget (void)
     this->selected_view = new SelectedView();
 
     /* MVS layout. */
-    mvs::Settings const default_settings;
+    mvs::Settings default_settings;
     this->mvs_color_scale.setText("Enable Color Scale");
     this->mvs_color_scale.setChecked(default_settings.useColorScale);
     this->mvs_write_ply.setText("Write PLY after recon");


### PR DESCRIPTION
Dropping `const` declaration of settings struct. 
According to C standard, objects need to have a
user-defined constructor if instances are delcared const.