### PR TITLE
MVE: Fix output of ply writer for point clouds

### DIFF
--- a/libs/mve/mesh_io_ply.cc
+++ b/libs/mve/mesh_io_ply.cc
@@ -713,9 +713,9 @@ save_ply_mesh (TriangleMesh::ConstPtr mesh, std::string const& filename,
     write_vconfidences = write_vconfidences && verts.size() == conf.size();
     bool write_vvalues = options.write_vertex_values;
     write_vvalues = write_vvalues && verts.size() == vvalues.size();
-    bool write_fcolors = options.write_face_colors;
+    bool write_fcolors = options.write_face_colors && face_amount;
     write_fcolors = write_fcolors && fcolors.size() == face_amount;
-    bool write_fnormals = options.write_face_normals;
+    bool write_fnormals = options.write_face_normals && face_amount;
     write_fnormals = write_fnormals && fnormals.size() == face_amount;
 
     std::string format_str = (options.format_binary


### PR DESCRIPTION
```Writing PLY file (4264985 verts, with normals, 0 faces, with colors)... done.```
vs.
```Writing PLY file (4264985 verts, with normals, 0 faces)... done.```

Zero faces with colors is somewhat irritating, since colors could still be specified in the ply header... 