### PR TITLE
SFM: Add surf features to matching test app

### DIFF
--- a/libs/sfm/cascade_hashing.cc
+++ b/libs/sfm/cascade_hashing.cc
@@ -100,42 +100,7 @@ CascadeHashing::pairwise_match (int view_1_id, int view_2_id,
         Matching::remove_inconsistent_matches(&surf_result);
     }
 
-    /* TODO: The following code is the same as in
-     *       ExhaustiveMatching::pairwise_match() and could be moved into a
-     *       separate function to avoid code duplication.
-     */
-    /* Fix offsets in the matching result. */
-    std::size_t other_surf_offset = pfs_2.sift_descr.size();
-    if (other_surf_offset > 0)
-        for (std::size_t i = 0; i < surf_result.matches_1_2.size(); ++i)
-            if (surf_result.matches_1_2[i] >= 0)
-                surf_result.matches_1_2[i] += other_surf_offset;
-
-    std::size_t this_surf_offset = pfs_1.sift_descr.size();
-    if (this_surf_offset > 0)
-        for (std::size_t i = 0; i < surf_result.matches_2_1.size(); ++i)
-            if (surf_result.matches_2_1[i] >= 0)
-                surf_result.matches_2_1[i] += this_surf_offset;
-
-    /* Create a combined matching result. */
-    std::size_t this_num_descriptors = pfs_1.sift_descr.size()
-        + pfs_1.surf_descr.size();
-    std::size_t other_num_descriptors = pfs_2.sift_descr.size()
-        + pfs_2.surf_descr.size();
-
-    result->matches_1_2.clear();
-    result->matches_1_2.reserve(this_num_descriptors);
-    result->matches_1_2.insert(result->matches_1_2.end(),
-        sift_result.matches_1_2.begin(), sift_result.matches_1_2.end());
-    result->matches_1_2.insert(result->matches_1_2.end(),
-        surf_result.matches_1_2.begin(), surf_result.matches_1_2.end());
-
-    result->matches_2_1.clear();
-    result->matches_2_1.reserve(other_num_descriptors);
-    result->matches_2_1.insert(result->matches_2_1.end(),
-        sift_result.matches_2_1.begin(), sift_result.matches_2_1.end());
-    result->matches_2_1.insert(result->matches_2_1.end(),
-        surf_result.matches_2_1.begin(), surf_result.matches_2_1.end());
+    Matching::combine_results(sift_result, surf_result, result);
 }
 
 void

--- a/libs/sfm/exhaustive_matching.cc
+++ b/libs/sfm/exhaustive_matching.cc
@@ -136,38 +136,7 @@ ExhaustiveMatching::pairwise_match (int view_1_id, int view_2_id,
         Matching::remove_inconsistent_matches(&surf_result);
     }
 
-    /* Fix offsets in the matching result. */
-    std::size_t other_surf_offset = pfs_2.sift_descr.size();
-    if (other_surf_offset > 0)
-        for (std::size_t i = 0; i < surf_result.matches_1_2.size(); ++i)
-            if (surf_result.matches_1_2[i] >= 0)
-                surf_result.matches_1_2[i] += other_surf_offset;
-
-    std::size_t this_surf_offset = pfs_1.sift_descr.size();
-    if (this_surf_offset > 0)
-        for (std::size_t i = 0; i < surf_result.matches_2_1.size(); ++i)
-            if (surf_result.matches_2_1[i] >= 0)
-                surf_result.matches_2_1[i] += this_surf_offset;
-
-    /* Create a combined matching result. */
-    std::size_t this_num_descriptors = pfs_1.sift_descr.size()
-        + pfs_1.surf_descr.size();
-    std::size_t other_num_descriptors = pfs_2.sift_descr.size()
-        + pfs_2.surf_descr.size();
-
-    result->matches_1_2.clear();
-    result->matches_1_2.reserve(this_num_descriptors);
-    result->matches_1_2.insert(result->matches_1_2.end(),
-        sift_result.matches_1_2.begin(), sift_result.matches_1_2.end());
-    result->matches_1_2.insert(result->matches_1_2.end(),
-        surf_result.matches_1_2.begin(), surf_result.matches_1_2.end());
-
-    result->matches_2_1.clear();
-    result->matches_2_1.reserve(other_num_descriptors);
-    result->matches_2_1.insert(result->matches_2_1.end(),
-        sift_result.matches_2_1.begin(), sift_result.matches_2_1.end());
-    result->matches_2_1.insert(result->matches_2_1.end(),
-        surf_result.matches_2_1.begin(), surf_result.matches_2_1.end());
+    Matching::combine_results(sift_result, surf_result, result);
 }
 
 int

--- a/libs/sfm/matching.cc
+++ b/libs/sfm/matching.cc
@@ -46,4 +46,45 @@ Matching::count_consistent_matches (Matching::Result const& matches)
     return counter;
 }
 
+void
+Matching::combine_results(Matching::Result const& sift_result,
+    Matching::Result const& surf_result, Matching::Result* result)
+{
+    /* Determine size of combined matching result. */
+    std::size_t num_matches_1 = sift_result.matches_1_2.size()
+        + surf_result.matches_1_2.size();
+    std::size_t num_matches_2 = sift_result.matches_2_1.size()
+        + surf_result.matches_2_1.size();
+
+    /* Combine results. */
+    result->matches_1_2.clear();
+    result->matches_1_2.reserve(num_matches_1);
+    result->matches_1_2.insert(result->matches_1_2.end(),
+        sift_result.matches_1_2.begin(), sift_result.matches_1_2.end());
+    result->matches_1_2.insert(result->matches_1_2.end(),
+        surf_result.matches_1_2.begin(), surf_result.matches_1_2.end());
+
+    result->matches_2_1.clear();
+    result->matches_2_1.reserve(num_matches_2);
+    result->matches_2_1.insert(result->matches_2_1.end(),
+        sift_result.matches_2_1.begin(), sift_result.matches_2_1.end());
+    result->matches_2_1.insert(result->matches_2_1.end(),
+        surf_result.matches_2_1.begin(), surf_result.matches_2_1.end());
+
+    /* Fix offsets. */
+    std::size_t surf_offset_1 = sift_result.matches_1_2.size();
+    std::size_t surf_offset_2 = sift_result.matches_2_1.size();
+
+    if (surf_offset_2 > 0)
+        for (std::size_t i = surf_offset_1; i < result->matches_1_2.size(); ++i)
+            if (result->matches_1_2[i] >= 0)
+                result->matches_1_2[i] += surf_offset_2;
+
+    if (surf_offset_1 > 0)
+        for (std::size_t i = surf_offset_2; i < result->matches_2_1.size(); ++i)
+            if (result->matches_2_1[i] >= 0)
+                result->matches_2_1[i] += surf_offset_1;
+
+}
+
 SFM_NAMESPACE_END

--- a/libs/sfm/matching.h
+++ b/libs/sfm/matching.h
@@ -98,6 +98,13 @@ public:
      */
     static int
     count_consistent_matches (Result const& matches);
+
+    /**
+     * Combines matching results of different descriptors.
+     */
+    static void
+    combine_results(Result const& sift_result,
+        Result const& surf_result, Matching::Result* result);
 };
 
 /* ---------------------------------------------------------------- */


### PR DESCRIPTION
Further these commits:
- eliminate code duplication (`Matching::combine_results`)
- fix an uninitialized value bug (`sfm::Matching::Options::distance_threshold`)
- allow the inspection of  discretized matching results (which were found to be quite different)