### PR TITLE
SFM: Limit matches for least squares fundamental estimation #264

### DIFF
--- a/libs/sfm/bundler_init_pair.cc
+++ b/libs/sfm/bundler_init_pair.cc
@@ -223,6 +223,11 @@ InitialPair::compute_pose (CandidatePair const& candidate,
     FundamentalMatrix fundamental;
     {
         Correspondences2D2D matches = candidate.matches;
+        if (matches.size() > 1000ul) {
+            std::mt19937 g;
+            std::shuffle(matches.begin(), matches.end(), g);
+            matches.resize(1000ul);
+        }
         fundamental_least_squares(matches, &fundamental);
         enforce_fundamental_constraints(&fundamental);
     }


### PR DESCRIPTION
The amount of memory required for the least squares fundamental estimation increases quad radically with the number of matches #264. Limiting the number of matches should result in a significant reduction in memory usage for scenes with a high amount of pairwise matches and would have little impact on scenes with lower amount of pairwise matches.

The limit of 1000 matches is exemplary and should be discussed.