### PR TITLE
OGL: Explicitly set primitive type in MeshRenderer::set_mesh()

### DIFF
--- a/libs/ogl/mesh_renderer.cc
+++ b/libs/ogl/mesh_renderer.cc
@@ -40,6 +40,9 @@ MeshRenderer::set_mesh (mve::TriangleMesh::ConstPtr mesh)
         VertexBuffer::Ptr vbo = ogl::VertexBuffer::create();
         vbo->set_indices(&faces[0], (GLsizei)faces.size());
         this->set_index_vbo(vbo);
+        this->set_primitive(GL_TRIANGLES);
+    } else {
+        this->set_primitive(GL_POINTS);
     }
 
     /* Init normal VBO if normals are given. */


### PR DESCRIPTION
There is a potential bug in the `MeshRenderer` class when calling
[`MeshRenderer::set_mesh()`](https://github.com/simonfuhrmann/mve/blob/cab91ca2fc33d6b3857c9482e8cfb26002fa0596/libs/ogl/mesh_renderer.cc#L16) with a point cloud. The primitive type is left at
`GL_TRIANGLES`, as initialized in the [ctor](https://github.com/simonfuhrmann/mve/blob/cab91ca2fc33d6b3857c9482e8cfb26002fa0596/libs/ogl/vertex_array.h#L89) of `VertexArray` of which
`MeshRenderer` is derived from. Then, when [`MeshRenderer/VertexArray::draw()`](https://github.com/simonfuhrmann/mve/blob/cab91ca2fc33d6b3857c9482e8cfb26002fa0596/libs/ogl/vertex_array.cc#L56) is
called, triangles are drawn instead of points. Explicitly setting the
primitive type in `MeshRenderer::set_mesh()` fixes the issue.