### PR TITLE
SFM: Fix initial pair failure when triangulation fails

### DIFF
--- a/apps/sfmrecon/sfmrecon.cc
+++ b/apps/sfmrecon/sfmrecon.cc
@@ -255,7 +255,7 @@ sfm_reconstruct (AppSettings const& conf)
         //init_pair_opts.homography_opts.max_iterations = 1000;
         //init_pair_opts.homography_opts.threshold = 0.005f;
         init_pair_opts.homography_opts.verbose_output = false;
-        init_pair_opts.max_homography_inliers = 0.6f;
+        init_pair_opts.max_homography_inliers = 0.8f;
         init_pair_opts.verbose_output = true;
 
         sfm::bundler::InitialPair init_pair(init_pair_opts);


### PR DESCRIPTION
Add an additional check to the initial pair selection to test if two-view triangulation works for a significant amount of matches.

- This fixes many failures that usually occur when the two-view geometry from the initial pair selection is not optimal and a continued bundling is not possible.  
- Due to this we can also relax the homography test a little bit; which helps significantly for urban scenes where large homographies are very common but it is still possible to find an initial pair. 

We already tested this internally in the context of CR-PLAY.