### PR TITLE
APPS: read in cam files if available

### DIFF
--- a/apps/makescene/makescene.cc
+++ b/apps/makescene/makescene.cc
@@ -774,7 +774,8 @@ find_corresponding_cam_file(util::fs::Directory const & dir, std::size_t i,
     std::string prefix = remove_file_extension(dir[i].name);
 
     /* Look at files behind the given file until the prefix changes. */
-    for (std::size_t j = i + 1; j < dir.size(); ++j) {
+    for (std::size_t j = i + 1; j < dir.size(); ++j)
+    {
         if (dir[j].is_dir)
             continue;
 
@@ -788,14 +789,16 @@ find_corresponding_cam_file(util::fs::Directory const & dir, std::size_t i,
             break;
 
         std::string ext = fname.substr(pos + 1, fname.size());
-        if (util::string::lowercase(ext) == "cam") {
+        if (util::string::lowercase(ext) == "cam")
+        {
             *acfname = dir[j].get_absolute_name();
             return true;
         }
     }
 
     /* Look at files before the given file until the prefix changes. */
-    for (int j = i - 1; 0 <= j; --j) {
+    for (int j = i - 1; 0 <= j; --j)
+    {
         if (dir[j].is_dir)
             continue;
 
@@ -809,7 +812,8 @@ find_corresponding_cam_file(util::fs::Directory const & dir, std::size_t i,
             break;
 
         std::string ext = fname.substr(pos + 1, fname.size());
-        if (util::string::lowercase(ext) == "cam") {
+        if (util::string::lowercase(ext) == "cam")
+        {
             *acfname = dir[j].get_absolute_name();
             return true;
         }
@@ -934,7 +938,8 @@ import_images (AppSettings const& conf)
         view->set_name(remove_file_extension(fname));
 
         std::string acfname;
-        if (find_corresponding_cam_file(dir, i, &acfname)) {
+        if (find_corresponding_cam_file(dir, i, &acfname))
+        {
             try
             {
                 view->set_camera(load_cam_file(acfname));

--- a/apps/makescene/makescene.cc
+++ b/apps/makescene/makescene.cc
@@ -766,14 +766,14 @@ find_max_scene_id (std::string const& view_path)
 
 /* ---------------------------------------------------------------- */
 
-/* Find corresponding cam file to file i in sorted directory. */
+/* Find corresponding cam file to image file i in sorted directory. */
 bool
 find_corresponding_cam_file(util::fs::Directory const & dir, std::size_t i,
     std::string * acfname)
 {
     std::string prefix = remove_file_extension(dir[i].name);
 
-    /* Look at files behind the given file until the prefix changes */
+    /* Look at files behind the given file until the prefix changes. */
     for (std::size_t j = i + 1; j < dir.size(); ++j) {
         if (dir[j].is_dir)
             continue;
@@ -794,7 +794,7 @@ find_corresponding_cam_file(util::fs::Directory const & dir, std::size_t i,
         }
     }
 
-    /* Look at files before the given file until the prefix changes */
+    /* Look at files before the given file until the prefix changes. */
     for (int j = i - 1; 0 <= j; --j) {
         if (dir[j].is_dir)
             continue;
@@ -913,6 +913,7 @@ import_images (AppSettings const& conf)
         std::string fname = dir[i].name;
         std::string afname = dir[i].get_absolute_name();
 
+        /* Ignore cam files. */
         if (fname.size() > 3 && util::string::right(fname, 4) == ".cam")
             continue;
 

--- a/apps/makescene/makescene.cc
+++ b/apps/makescene/makescene.cc
@@ -766,6 +766,101 @@ find_max_scene_id (std::string const& view_path)
 
 /* ---------------------------------------------------------------- */
 
+/* Find corresponding cam file to file i in sorted directory. */
+bool
+find_corresponding_cam_file(util::fs::Directory const & dir, std::size_t i,
+    std::string * acfname)
+{
+    std::string prefix = remove_file_extension(dir[i].name);
+
+    /* Look at files behind the given file until the prefix changes */
+    for (std::size_t j = i + 1; j < dir.size(); ++j) {
+        if (dir[j].is_dir)
+            continue;
+
+        std::string const & fname = dir[j].name;
+
+        std::size_t pos = fname.find_last_of('.');
+        if (pos == std::string::npos)
+            continue;
+
+        if (fname.substr(0, pos) != prefix)
+            break;
+
+        std::string ext = fname.substr(pos + 1, fname.size());
+        if (util::string::lowercase(ext) == "cam") {
+            *acfname = dir[j].get_absolute_name();
+            return true;
+        }
+    }
+
+    /* Look at files before the given file until the prefix changes */
+    for (int j = i - 1; 0 <= j; --j) {
+        if (dir[j].is_dir)
+            continue;
+
+        std::string const & fname = dir[j].name;
+
+        std::size_t pos = fname.find_last_of('.');
+        if (pos == std::string::npos)
+            continue;
+
+        if (fname.substr(0, pos) != prefix)
+            break;
+
+        std::string ext = fname.substr(pos + 1, fname.size());
+        if (util::string::lowercase(ext) == "cam") {
+            *acfname = dir[j].get_absolute_name();
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/* ---------------------------------------------------------------- */
+
+mve::CameraInfo
+load_cam_file(std::string const & filename)
+{
+    std::ifstream in(filename.c_str(), std::ios::binary);
+
+    if (!in.good())
+        throw util::FileException(util::fs::basename(filename), std::strerror(errno));
+
+    std::string cam_int_str, cam_ext_str;
+    std::getline(in, cam_ext_str);
+    std::getline(in, cam_int_str);
+
+    util::Tokenizer tok_ext, tok_int;
+    tok_ext.split(cam_ext_str);
+    tok_int.split(cam_int_str);
+
+    if (tok_ext.size() != 12 || tok_int.size() < 1)
+        throw util::Exception("Invalid cam file");
+
+    mve::CameraInfo cam;
+    cam.set_translation_from_string(tok_ext.concat(0, 3));
+    cam.set_rotation_from_string(tok_ext.concat(3, 0));
+
+    std::stringstream ss(cam_int_str);
+    ss >> cam.flen;
+    if (ss.peek() && !ss.eof())
+        ss >> cam.dist[0];
+    if (ss.peek() && !ss.eof())
+        ss >> cam.dist[1];
+    if (ss.peek() && !ss.eof())
+        ss >> cam.paspect;
+    if (ss.peek() && !ss.eof())
+        ss >> cam.ppoint[0];
+    if (ss.peek() && !ss.eof())
+        ss >> cam.ppoint[1];
+
+    return cam;
+}
+
+/* ---------------------------------------------------------------- */
+
 void
 import_images (AppSettings const& conf)
 {
@@ -818,6 +913,9 @@ import_images (AppSettings const& conf)
         std::string fname = dir[i].name;
         std::string afname = dir[i].get_absolute_name();
 
+        if (fname.size() > 3 && util::string::right(fname, 4) == ".cam")
+            continue;
+
         std::string exif;
         mve::ImageBase::Ptr image = load_any_image(afname, &exif);
         if (image == nullptr)
@@ -833,6 +931,26 @@ import_images (AppSettings const& conf)
         mve::View::Ptr view = mve::View::create();
         view->set_id(id);
         view->set_name(remove_file_extension(fname));
+
+        std::string acfname;
+        if (find_corresponding_cam_file(dir, i, &acfname)) {
+            try
+            {
+                view->set_camera(load_cam_file(acfname));
+            }
+            catch (util::FileException &e)
+            {
+#pragma omp critical
+                std::cerr << e.filename << ": " << e.what() << std::endl;
+                std::exit(EXIT_FAILURE);
+            }
+            catch (util::Exception &e)
+            {
+#pragma omp critical
+                std::cerr << acfname << ": " << e.what() << std::endl;
+                std::exit(EXIT_FAILURE);
+            }
+        }
 
         /* Rescale and add original image. */
         int orig_width = image->width();


### PR DESCRIPTION
This pull request would enable users to provide cam files along their image files to specify extrinsic and intrinsic camera parameters.

A cam file contains the camera part of the old MVE file header.

tx ty tz R00 R01 R02 R10 R11 R12 R20 R21 R22
f d0 d1 paspect ppx ppy

First line: Extrinsics - translation vector and rotation matrix
Second line: Intrinsics - focal length (normalized by dividing with the larger image dimension), distortion coefficients, pixel aspect ratio and principal point (in normalized coordinates [0,1])

If no cam files are available `makescene` behaves as before with a minimal overhead for the search of corresponding cam files (system calls are avoided by searching within the already parsed directory).
