### PR TITLE
UMVE: Skip histogram creation if image range exceeds float max

### DIFF
--- a/apps/umve/viewinspect/tonemapping.cc
+++ b/apps/umve/viewinspect/tonemapping.cc
@@ -416,7 +416,7 @@ ToneMapping::setup_histogram (void)
     std::vector<int> bins(num_bins, 0);
     float const image_range = this->image_vmax - this->image_vmin;
     /* Only build a histogram if the image is not constant. */
-    if (this->image_vmax != this->image_vmin)
+    if (this->image_vmax != this->image_vmin && std::isfinite(image_range))
     {
         for (float const* ptr = fimg.begin(); ptr != fimg.end(); ++ptr)
         {


### PR DESCRIPTION
The image range of a float image may exceed the range of float causing a segfault.

This patch skips the creation of the histogram.
Computing image range and bin in double precision would be the other possibility.