### PR TITLE
MATH: Fix unexpected behaviour with plane inversion

### DIFF
--- a/libs/math/line.h
+++ b/libs/math/line.h
@@ -27,10 +27,10 @@ template <class T>
 class Line3
 {
 public:
-    /** Creates an uninitialized plane. */
+    /** Creates an uninitialized line. */
     Line3 (void);
 
-    /** Creates a plane with normal n and distance d from the origin. */
+    /** Creates a line with normal n and distance d from the origin. */
     Line3 (math::Vector<T, 3> const& d, math::Vector<T, 3> const& p);
 
 public:

--- a/libs/math/plane.h
+++ b/libs/math/plane.h
@@ -47,7 +47,10 @@ public:
     T point_dist (Vec3T const& p) const;
 
     /** Flips the orientation of the plane. */
-    Plane3<T> invert (void) const;
+    Plane3<T>& invert (void);
+
+    /** Returns plane with flipped orientation. */
+    Plane3<T> inverted (void) const;
 
 public:
     Vec3T n;
@@ -92,8 +95,17 @@ Plane3<T>::point_dist (Vec3T const& p) const
 }
 
 template <class T>
+Plane3<T>&
+Plane3<T>::invert (void)
+{
+    n = -n;
+    d = -d;
+    return *this;
+}
+
+template <class T>
 inline Plane3<T>
-Plane3<T>::invert (void) const
+Plane3<T>::inverted (void) const
 {
     return Plane3<T>(-n, -d);
 }


### PR DESCRIPTION
Plane invert did not invert the plane, like the name suggests, but returned an inverted plane.