### PR TITLE
Extract gl matrix creation

### DIFF
--- a/apps/umve/scene_addins/addin_rephotographer.cc
+++ b/apps/umve/scene_addins/addin_rephotographer.cc
@@ -105,40 +105,15 @@ AddinRephotographer::on_rephoto_view (mve::View::Ptr view)
     /* Backup camera. */
     ogl::Camera camera_backup = *this->camera;
 
-    /* Get all parameters and check them. */
-    mve::CameraInfo const& camera_info = view->get_camera();
     int const width = view->get_image_proxy(source_name)->width;
     int const height = view->get_image_proxy(source_name)->height;
-    float const dimension_aspect = static_cast<float>(width) / height;
-    float const pixel_aspect = camera_info.paspect;
-    float const image_aspect = dimension_aspect * pixel_aspect;
-    float const focal_length = camera_info.flen;
-    float const ppx = camera_info.ppoint[0];
-    float const ppy = camera_info.ppoint[1];
-
-    /* Fill OpenGL view matrix. */
-    math::Matrix4f& viewmat = this->camera->view;
-    camera_info.fill_world_to_cam(viewmat.begin());
-    /* Convert to OpenGL convention - flip y and z. */
-    for (int i = 0; i < 4; ++i) {
-        viewmat[4 + i] *= -1.0f;
-        viewmat[8 + i] *= -1.0f;
-    }
-
-    /* Fill OpenGL projection matrix. */
-    math::Matrix4f& projmat = this->camera->proj;
     float const znear = 0.1f;
     float const zfar = 1000.0f;
-    projmat.fill(0.0f);
-    projmat(0, 0) = 2.0f * focal_length
-        * (image_aspect > 1.0f ? 1.0f : 1.0f / image_aspect);
-    projmat(0, 2) = 2.0f * (ppx - 0.5f);
-    projmat(1, 1) = 2.0f * focal_length
-        * (image_aspect > 1.0f ? image_aspect : 1.0f);
-    projmat(1, 2) = 2.0f * (ppy - 0.5f);
-    projmat(2, 2) = -(zfar + znear) / (zfar - znear);
-    projmat(2, 3) = -2.0f * zfar * znear / (zfar - znear);
-    projmat(3, 2) = -1.0f;
+    mve::CameraInfo const& camera_info = view->get_camera();
+
+    camera_info.fill_gl_viewtrans(this->camera->view.begin());
+    camera_info.fill_gl_projection(this->camera->proj.begin(),
+        width, height, znear, zfar);
 
     /* Re-photograph. */
     this->request_context();

--- a/libs/mve/camera.cc
+++ b/libs/mve/camera.cc
@@ -69,6 +69,17 @@ CameraInfo::fill_world_to_cam (float* mat) const
 /* ---------------------------------------------------------------- */
 
 void
+CameraInfo::fill_gl_viewtrans (float* mat) const
+{
+    mat[0]  =  rot[0]; mat[1]  =  rot[1]; mat[2]  =  rot[2]; mat[3]  =  trans[0];
+    mat[4]  = -rot[3]; mat[5]  = -rot[4]; mat[6]  = -rot[5]; mat[7]  = -trans[1];
+    mat[8]  = -rot[6]; mat[9]  = -rot[7]; mat[10] = -rot[8]; mat[11] = -trans[2];
+    mat[12] =  0.0f;   mat[13] =  0.0f;   mat[14] =  0.0f;   mat[15] = 1.0f;
+}
+
+/* ---------------------------------------------------------------- */
+
+void
 CameraInfo::fill_cam_to_world (float* mat) const
 {
     mat[0]  = rot[0]; mat[1] = rot[3]; mat[2]  = rot[6];
@@ -130,6 +141,37 @@ CameraInfo::fill_calibration (float* mat, float width, float height) const
     mat[0] =   ax; mat[1] = 0.0f; mat[2] = width * this->ppoint[0];
     mat[3] = 0.0f; mat[4] =   ay; mat[5] = height * this->ppoint[1];
     mat[6] = 0.0f; mat[7] = 0.0f; mat[8] = 1.0f;
+}
+
+/* ---------------------------------------------------------------- */
+
+void
+CameraInfo::fill_gl_projection (float * mat, float width, float height,
+    float znear, float zfar) const
+{
+    float dim_aspect = width / height;
+    float image_aspect = dim_aspect * this->paspect;
+    float ax, ay;
+    if (image_aspect < 1.0f) /* Portrait. */
+    {
+        ax = this->flen / image_aspect;
+        ay = this->flen;
+    }
+    else /* Landscape */
+    {
+        ax = this->flen;
+        ay = this->flen * image_aspect;
+    }
+
+    std::fill(mat, mat + 16, 0.0f);
+
+    mat[4 * 0 + 0] = 2.0f * ax;
+    mat[4 * 0 + 2] = 2.0f * (this->ppoint[0] - 0.5f);
+    mat[4 * 1 + 1] = 2.0f * ay;
+    mat[4 * 1 + 2] = 2.0f * (this->ppoint[1] - 0.5f);
+    mat[4 * 2 + 2] = -(zfar + znear) / (zfar - znear);
+    mat[4 * 2 + 3] = -2.0f * zfar * znear / (zfar - znear);
+    mat[4 * 3 + 2] = -1.0f;
 }
 
 /* ---------------------------------------------------------------- */

--- a/libs/mve/camera.h
+++ b/libs/mve/camera.h
@@ -134,6 +134,17 @@ public:
     void set_translation_from_string (std::string const& trans_string);
 
     /**
+     * Stores OpenGl view transformation 4x4 matrix in array pointed to by mat.
+     */
+    void fill_gl_viewtrans (float* mat) const;
+
+    /**
+     * Stores OpenGl projection 4x4 matrix in array pointed to by mat.
+     */
+    void fill_gl_projection (float * mat, float width, float height,
+        float znear, float zfar) const;
+
+    /**
      * Prints debug information to stdout.
      */
     void debug_print (void) const;


### PR DESCRIPTION
I tried to put these functions into `math/matrix_tools.h` but the creation of the projection matrix requires a lot of information from `mve::CameraInfo` and relies on our camera convention so it felt more natural to put it into `mve::CameraInfo` directly.