### PR TITLE
Fix quaternion to rotation matrix conversion (wrong matrix convention)

### DIFF
--- a/apps/meshalign/stanford_alignment.cc
+++ b/apps/meshalign/stanford_alignment.cc
@@ -80,8 +80,10 @@ StanfordAlignment::read_alignment (std::string const& conffile)
             temp_rotation.to_rotation_matrix(ri.rotation.begin());
 
             /* This is a bit strange... */
-            ri.campos = ri.rotation * camera_rot.rotate(camera_pos) + ri.translation;
-            ri.viewdir = ri.rotation * camera_rot.rotate(math::Vec3f(0,0,1));
+            ri.campos = ri.rotation.transposed()
+                * camera_rot.conjugated().rotate(camera_pos) + ri.translation;
+            ri.viewdir = ri.rotation.transposed()
+                * camera_rot.conjugated().rotate(math::Vec3f(0.0f, 0.0f, 1.0f));
             this->images.push_back(ri);
         }
         else
@@ -100,7 +102,8 @@ StanfordAlignment::get_mesh (RangeImage const& ri)
     mve::TriangleMesh::Ptr ret;
     ret = mve::geom::load_mesh(ri.fullpath);
     mve::TriangleMesh::VertexList& verts(ret->get_vertices());
+    math::Matrix3f inv_rot = ri.rotation.transposed();
     for (std::size_t i = 0; i < verts.size(); ++i)
-        verts[i] = ri.rotation * verts[i] + ri.translation;
+        verts[i] = inv_rot * verts[i] + ri.translation;
     return ret;
 }

--- a/libs/math/quaternion.h
+++ b/libs/math/quaternion.h
@@ -169,13 +169,13 @@ Quaternion<T>::to_rotation_matrix (T* matrix) const
     T const zr2 = this->v[3] * this->v[0] * T(2);
 
     matrix[0] = xxzz + rryy;
-    matrix[1] = xy2 + zr2;
-    matrix[2] = xz2 - yr2;
-    matrix[3] = xy2 - zr2;
+    matrix[1] = xy2 - zr2;
+    matrix[2] = xz2 + yr2;
+    matrix[3] = xy2 + zr2;
     matrix[4] = yyrrxxzz;
-    matrix[5] = yz2 + xr2;
-    matrix[6] = xz2 + yr2;
-    matrix[7] = yz2 - xr2;
+    matrix[5] = yz2 - xr2;
+    matrix[6] = xz2 - yr2;
+    matrix[7] = yz2 + xr2;
     matrix[8] = rryy - xxzz;
 }
 

--- a/libs/ogl/camera_trackball.cc
+++ b/libs/ogl/camera_trackball.cc
@@ -116,9 +116,8 @@ CamTrackball::handle_tb_rotation (int x, int y)
     math::Vec3f bn_now = this->get_ball_normal(x, y);
 
     /* Rotation axis and angle. */
-    //math::Vec3f axis = bn_now.cross(bn_start);
-    math::Vec3f axis = bn_start.cross(bn_now);
-    float angle = std::acos(bn_start.dot(bn_now));
+    math::Vec3f axis = bn_now.cross(bn_start);
+    float angle = std::acos(bn_now.dot(bn_start));
 
     /* Rotate axis to world coords. Build inverse viewing matrix from
      * values stored at the time of mouse click.
@@ -126,15 +125,15 @@ CamTrackball::handle_tb_rotation (int x, int y)
     math::Matrix4f cam_to_world;
     math::Vec3f campos = this->tb_center + this->rot_tb_tocam * this->tb_radius;
     math::Vec3f viewdir = -this->rot_tb_tocam;
-    cam_to_world = math::matrix_viewtrans(campos, viewdir, this->rot_tb_upvec);
-    cam_to_world = math::matrix_invert_trans(cam_to_world);
+    cam_to_world = math::matrix_inverse_viewtrans(
+        campos, viewdir, this->rot_tb_upvec);
     axis = cam_to_world.mult(axis, 0.0f);
     axis.normalize();
 
     /* Rotate camera and up vector around axis. */
-    math::Quat4f rot(axis, angle);
-    this->tb_tocam = rot.rotate(this->rot_tb_tocam);
-    this->tb_upvec = rot.rotate(this->rot_tb_upvec);
+    math::Matrix3f rot = matrix_rotation_from_axis_angle(axis, angle);
+    this->tb_tocam = rot * this->rot_tb_tocam;
+    this->tb_upvec = rot * this->rot_tb_upvec;
 }
 
 /* ---------------------------------------------------------------- */

--- a/tests/math/gtest_quaternion.cc
+++ b/tests/math/gtest_quaternion.cc
@@ -1,0 +1,22 @@
+/*
+ * Test cases for the quaternion class.
+ * Written by Nils Moehrle.
+ */
+
+#include <gtest/gtest.h>
+
+#include "math/quaternion.h"
+
+TEST(QuaternionTest, Rotate)
+{
+    using namespace math;
+    Vec3f x(1.0f, 0.0f, 0.0f);
+    Vec3f y(0.0f, 1.0f, 0.0f);
+    Vec3f z(0.0f, 0.0f, 1.0f);
+
+    /* 90 deg ccw rotation around z. */
+    Quat4f q(z, M_PI / 2.0f);
+
+    float error = (y - q.rotate(x)).norm();
+    EXPECT_TRUE(error < 1e-7f);
+}


### PR DESCRIPTION
The rotation matrix is written out as column major, resulting in transposed rotations.