### PR TITLE
SFM: Improve worst case runtime of track propagation

### DIFF
--- a/libs/sfm/bundler_tracks.cc
+++ b/libs/sfm/bundler_tracks.cc
@@ -17,6 +17,37 @@
 SFM_NAMESPACE_BEGIN
 SFM_BUNDLER_NAMESPACE_BEGIN
 
+/*
+ * Merges tracks and updates viewports accordingly.
+ */
+void
+unify_tracks(int const view1_tid, int const view2_tid,
+    TrackList* tracks, ViewportList* viewports)
+{
+    Track& track1 = tracks->at(view1_tid);
+    Track& track2 = tracks->at(view2_tid);
+
+    /* Unify in larger track. */
+    if (track1.features.size() < track2.features.size())
+    {
+        unify_tracks(view2_tid, view1_tid, tracks, viewports);
+        return;
+    }
+
+    for (std::size_t k = 0; k < track2.features.size(); ++k)
+    {
+        int const view_id = track2.features[k].view_id;
+        int const feat_id = track2.features[k].feature_id;
+        viewports->at(view_id).track_ids[feat_id] = view1_tid;
+    }
+    track1.features.insert(track1.features.end(),
+        track2.features.begin(), track2.features.end());
+    /* Free old track's memory. clear() does not work. */
+    track2.features = FeatureReferenceList();
+}
+
+/* ---------------------------------------------------------------- */
+
 void
 Tracks::compute (PairwiseMatching const& matching,
     ViewportList* viewports, TrackList* tracks)
@@ -81,17 +112,7 @@ Tracks::compute (PairwiseMatching const& matching,
                  * A track ID is already associated with both ends of a match,
                  * however, is not consistent. Unify tracks.
                  */
-                Track& track1 = tracks->at(view1_tid);
-                Track& track2 = tracks->at(view2_tid);
-                for (std::size_t k = 0; k < track2.features.size(); ++k)
-                {
-                    int const view_id = track2.features[k].view_id;
-                    int const feat_id = track2.features[k].feature_id;
-                    viewports->at(view_id).track_ids[feat_id] = view1_tid;
-                    track1.features.push_back(track2.features[k]);
-                }
-                /* Free old track's memory. clear() does not work. */
-                track2.features = FeatureReferenceList();
+                unify_tracks(view1_tid, view2_tid, tracks, viewports);
             }
         }
     }


### PR DESCRIPTION
I encountered a dataset where the track propagation did not complete after 24 hours. Unifying in the larger of both tracks and effectively reserving the required memory beforehand with `insert` reduced the runtime to under 15 seconds.