### PR TITLE
Normals

### DIFF
--- a/apps/umve/scene_addins/addin_mesh_renderer.h
+++ b/apps/umve/scene_addins/addin_mesh_renderer.h
@@ -15,6 +15,8 @@
 #include <QWidget>
 #include <QCheckBox>
 #include <QBoxLayout>
+#include <QDoubleSpinBox>
+#include <QFormLayout>
 
 #include "mve/mesh.h"
 
@@ -43,6 +45,10 @@ private:
     QVBoxLayout* render_meshes_box;
     QCheckBox* render_lighting_cb;
     QCheckBox* render_wireframe_cb;
+    QCheckBox* render_normals_face_cb;
+    QCheckBox* render_normals_vert_cb;
+    QFormLayout* normals_form;
+    QDoubleSpinBox* normals_size;
     QCheckBox* render_color_cb;
     QMeshList* mesh_list;
 };

--- a/apps/umve/scene_addins/addin_state.cc
+++ b/apps/umve/scene_addins/addin_state.cc
@@ -93,6 +93,10 @@ AddinState::load_shaders (void)
         this->texture_shader = ogl::ShaderProgram::create();
     if (!this->overlay_shader)
         this->overlay_shader = ogl::ShaderProgram::create();
+    if (!this->normals_face_shader)
+        this->normals_face_shader = ogl::ShaderProgram::create();
+    if (!this->normals_vert_shader)
+        this->normals_vert_shader = ogl::ShaderProgram::create();
 
     /* Setup search paths for shader files. */
     std::string home_dir = util::fs::get_home_dir();
@@ -107,6 +111,8 @@ AddinState::load_shaders (void)
     bool found_wireframe = false;
     bool found_texture = false;
     bool found_overlay = false;
+    bool found_normals_face = false;
+    bool found_normals_vert = false;
     for (std::size_t i = 0; i < shader_paths.size(); ++i)
     {
         try
@@ -123,6 +129,18 @@ AddinState::load_shaders (void)
             if (!found_overlay)
                 found_overlay = this->overlay_shader->try_load_all
                     (shader_paths[i] + "overlay_330");
+            if (!found_normals_face)
+                found_normals_face =
+                    this->normals_face_shader->try_load_specific(
+                        shader_paths[i] + "normals_330.vert",
+                        shader_paths[i] + "normals_face_330.geom",
+                        shader_paths[i] + "normals_330.frag");
+            if (!found_normals_vert)
+                found_normals_vert =
+                    this->normals_vert_shader->try_load_specific(
+                        shader_paths[i] + "normals_330.vert",
+                        shader_paths[i] + "normals_vert_330.geom",
+                        shader_paths[i] + "normals_330.frag");
         }
         catch (util::Exception& e)
         {
@@ -179,6 +197,16 @@ AddinState::send_uniform (ogl::Camera const& cam)
     this->texture_shader->bind();
     this->texture_shader->send_uniform("viewmat", cam.view);
     this->texture_shader->send_uniform("projmat", cam.proj);
+
+    /* Setup face normals shader. */
+    this->normals_face_shader->bind();
+    this->normals_face_shader->send_uniform("viewmat", cam.view);
+    this->normals_face_shader->send_uniform("projmat", cam.proj);
+
+    /* Setup vertex normals shader. */
+    this->normals_vert_shader->bind();
+    this->normals_vert_shader->send_uniform("viewmat", cam.view);
+    this->normals_vert_shader->send_uniform("projmat", cam.proj);
 
     /* Setup overlay shader. */
     this->overlay_shader->bind();

--- a/apps/umve/scene_addins/addin_state.h
+++ b/apps/umve/scene_addins/addin_state.h
@@ -28,6 +28,8 @@ public:
     ogl::ShaderProgram::Ptr wireframe_shader;
     ogl::ShaderProgram::Ptr texture_shader;
     ogl::ShaderProgram::Ptr overlay_shader;
+    ogl::ShaderProgram::Ptr normals_face_shader;
+    ogl::ShaderProgram::Ptr normals_vert_shader;
     mve::Scene::Ptr scene;
     mve::View::Ptr view;
 

--- a/apps/umve/shaders/normals_330.frag
+++ b/apps/umve/shaders/normals_330.frag
@@ -1,0 +1,11 @@
+#version 330 core
+
+layout(location=0) out vec4 frag_color;
+uniform vec4 ccolor = vec4(0.0, 0.5, 0.5, 0.9);
+
+void main(void)
+{
+    gl_FragDepth = gl_FragCoord.z;
+    frag_color = ccolor;
+}
+

--- a/apps/umve/shaders/normals_330.vert
+++ b/apps/umve/shaders/normals_330.vert
@@ -1,0 +1,14 @@
+#version 330 core
+
+in vec4 pos;
+in vec3 normal;
+
+out vec4 vpos;
+out vec3 vnormal;
+
+void main(void)
+{
+    vnormal = normal;
+    vpos = pos;
+}
+

--- a/apps/umve/shaders/normals_face_330.geom
+++ b/apps/umve/shaders/normals_face_330.geom
@@ -1,0 +1,32 @@
+#version 330 core
+
+layout(triangles) in;
+layout(line_strip, max_vertices = 2) out;
+
+in vec4 vpos[];
+in vec3 vnormal[];
+
+uniform mat4 viewmat;
+uniform mat4 projmat;
+uniform float len = 0.01; // normal length
+
+void draw_normal(vec3 pos, vec3 direction, float len)
+{
+    gl_Position = projmat * (viewmat * vec4(pos, 1.0));
+    EmitVertex();
+
+    vec3 end = pos + direction * len;
+    gl_Position = projmat * (viewmat * vec4(end, 1.0));
+    EmitVertex();
+
+    EndPrimitive();
+}
+
+void main(void)
+{
+    vec3 ab =  vpos[1].xyz - vpos[0].xyz;
+    vec3 ac =  vpos[2].xyz - vpos[0].xyz;
+    vec3 fnormal = normalize(cross(ab, ac));
+    vec3 fcentroid = (vpos[0].xyz + vpos[1].xyz + vpos[2].xyz) / 3.0;
+    draw_normal(fcentroid, fnormal, len);
+}

--- a/apps/umve/shaders/normals_vert_330.geom
+++ b/apps/umve/shaders/normals_vert_330.geom
@@ -1,0 +1,30 @@
+#version 330 core
+
+layout(points) in;
+layout(line_strip, max_vertices = 2) out;
+
+in vec4 vpos[];
+in vec3 vnormal[];
+
+uniform mat4 viewmat;
+uniform mat4 projmat;
+uniform float len = 0.01; // normal length
+
+void draw_normal(vec3 pos, vec3 direction, float len)
+{
+    gl_Position = projmat * (viewmat * vec4(pos, 1.0));
+    EmitVertex();
+
+    vec3 end = pos + direction * len;
+    gl_Position = projmat * (viewmat * vec4(end, 1.0));
+    EmitVertex();
+
+    EndPrimitive();
+}
+
+void main(void)
+{
+    vec3 pos = vpos[0].xyz;
+    vec3 normal = normalize(vnormal[0]);
+    draw_normal(pos, normal, len);
+}

--- a/libs/ogl/shader_program.cc
+++ b/libs/ogl/shader_program.cc
@@ -101,18 +101,24 @@ ShaderProgram::compile_shader (GLuint shader_id, std::string const& code)
 bool
 ShaderProgram::try_load_all (std::string const& basename)
 {
-    std::string vert_filename = basename + ".vert";
-    std::string geom_filename = basename + ".geom";
-    std::string frag_filename = basename + ".frag";
+    return try_load_specific(basename + ".vert", basename + ".geom",
+        basename + ".frag");
+}
 
+bool
+ShaderProgram::try_load_specific (std::string const& vert_filename,
+    std::string const& geom_filename, std::string const& frag_filename)
+{
     if (!util::fs::file_exists(vert_filename.c_str())
      || !util::fs::file_exists(frag_filename.c_str()))
     {
-        std::cerr << "Skipping shaders from " << basename << ".*" << std::endl;
+        std::cerr << "Skipping shaders " << vert_filename << " and "
+            << frag_filename << std::endl;
         return false;
     }
 
-    std::cerr << "Loading shaders from " << basename << ".*" << std::endl;
+    std::cout << "Loading shaders " << vert_filename << " and "
+        << frag_filename << std::endl;
 
     this->load_vert_file(vert_filename);
 

--- a/libs/ogl/shader_program.h
+++ b/libs/ogl/shader_program.h
@@ -45,6 +45,12 @@ public:
      */
     bool try_load_all (std::string const& basename);
 
+    /**
+     * Try loading shaders with specific filenames.
+     */
+    bool try_load_specific (std::string const& vert_filename,
+        std::string const& geom_filename, std::string const& frag_filename);
+
     /** Loads a vertex shader from file. */
     void load_vert_file (std::string const& filename);
     /** Loads optional geometry shader from file. */


### PR DESCRIPTION
This PR implements face and vertex normal rendering in UMVE. I have refactored shader loading to support vert/geom/frag shaders with different basenames and implemented two geom shaders for vertex/face normal generation as well as one simple vert and frag shader. The length of the normals is calculated with a 2^x function and the default size looks good for meshes in the unit cube.