### PR TITLE
UMVE: Change GL widget to newer QOpenGLWidget

### DIFF
--- a/apps/umve/glwidget.cc
+++ b/apps/umve/glwidget.cc
@@ -9,17 +9,14 @@
 
 #include <ctime>
 #include <iostream>
+#include <QApplication>
 
 #include "ogl/opengl.h"
 #include "ogl/events.h"
 #include "glwidget.h"
 
-#if QT_VERSION >= 0x050000
-#   include <QWindow>
-#endif
-
 GLWidget::GLWidget (QWidget *parent)
-    : QGLWidget(parent)
+    : QOpenGLWidget(parent)
     , context(nullptr)
     , gl_width(0)
     , gl_height(0)
@@ -27,6 +24,11 @@ GLWidget::GLWidget (QWidget *parent)
 {
     this->setFocusPolicy(Qt::ClickFocus);
     this->makeCurrent();
+    this->device_pixel_ratio = 1;
+#if QT_VERSION >= 0x050000
+    this->device_pixel_ratio = static_cast<QGuiApplication *>(
+        QApplication::instance())->devicePixelRatio();
+#endif
 
     /* This timer triggers a repaint after all events in the window system's
      * event queue have been processed. Thus a snappy 3D view is provided. */
@@ -53,6 +55,9 @@ GLWidget::initializeGL()
 void
 GLWidget::resizeGL(int width, int height)
 {
+    width *= this->device_pixel_ratio;
+    height *= this->device_pixel_ratio;
+
     std::cout << "Resizing GL from "
         << this->gl_width << "x" << this->gl_height << " to "
         << width << "x" << height << std::endl;
@@ -104,18 +109,13 @@ GLWidget::set_context (ogl::Context* context)
 void
 GLWidget::mousePressEvent (QMouseEvent *event)
 {
+    this->makeCurrent();
     ogl::MouseEvent e;
     e.type = ogl::MOUSE_EVENT_PRESS;
     e.button = (ogl::MouseButton)event->button();
     e.button_mask = event->buttons();
-#if QT_VERSION >= 0x050000
-    qreal const pixel_ratio = this->windowHandle()->devicePixelRatio();
-    e.x = static_cast<int>(event->x() * pixel_ratio);
-    e.y = static_cast<int>(event->y() * pixel_ratio);
-#else
-    e.x = event->x();
-    e.y = event->y();
-#endif
+    e.x = event->x() * this->device_pixel_ratio;
+    e.y = event->y() * this->device_pixel_ratio;
     this->context->mouse_event(e);
     this->repaint_async();
 }
@@ -125,18 +125,13 @@ GLWidget::mousePressEvent (QMouseEvent *event)
 void
 GLWidget::mouseReleaseEvent (QMouseEvent *event)
 {
+    this->makeCurrent();
     ogl::MouseEvent e;
     e.type = ogl::MOUSE_EVENT_RELEASE;
     e.button = (ogl::MouseButton)event->button();
     e.button_mask = event->buttons();
-#if QT_VERSION >= 0x050000
-    qreal const pixel_ratio = this->windowHandle()->devicePixelRatio();
-    e.x = static_cast<int>(event->x() * pixel_ratio);
-    e.y = static_cast<int>(event->y() * pixel_ratio);
-#else
-    e.x = event->x();
-    e.y = event->y();
-#endif
+    e.x = event->x() * this->device_pixel_ratio;
+    e.y = event->y() * this->device_pixel_ratio;
     this->context->mouse_event(e);
     this->repaint_async();
 }
@@ -146,18 +141,13 @@ GLWidget::mouseReleaseEvent (QMouseEvent *event)
 void
 GLWidget::mouseMoveEvent (QMouseEvent *event)
 {
+    this->makeCurrent();
     ogl::MouseEvent e;
     e.type = ogl::MOUSE_EVENT_MOVE;
     e.button = (ogl::MouseButton)event->button();
     e.button_mask = event->buttons();
-#if QT_VERSION >= 0x050000
-    qreal const pixel_ratio = this->windowHandle()->devicePixelRatio();
-    e.x = static_cast<int>(event->x() * pixel_ratio);
-    e.y = static_cast<int>(event->y() * pixel_ratio);
-#else
-    e.x = event->x();
-    e.y = event->y();
-#endif
+    e.x = event->x() * this->device_pixel_ratio;
+    e.y = event->y() * this->device_pixel_ratio;
     this->context->mouse_event(e);
     this->repaint_async();
 }
@@ -167,6 +157,7 @@ GLWidget::mouseMoveEvent (QMouseEvent *event)
 void
 GLWidget::wheelEvent (QWheelEvent* event)
 {
+    this->makeCurrent();
     ogl::MouseEvent e;
     if (event->delta() < 0)
         e.type = ogl::MOUSE_EVENT_WHEEL_DOWN;
@@ -174,14 +165,8 @@ GLWidget::wheelEvent (QWheelEvent* event)
         e.type = ogl::MOUSE_EVENT_WHEEL_UP;
     e.button = ogl::MOUSE_BUTTON_NONE;
     e.button_mask = event->buttons();
-#if QT_VERSION >= 0x050000
-    qreal const pixel_ratio = this->windowHandle()->devicePixelRatio();
-    e.x = static_cast<int>(event->x() * pixel_ratio);
-    e.y = static_cast<int>(event->y() * pixel_ratio);
-#else
-    e.x = event->x();
-    e.y = event->y();
-#endif
+    e.x = event->x() * this->device_pixel_ratio;
+    e.y = event->y() * this->device_pixel_ratio;
     this->context->mouse_event(e);
     this->repaint_async();
 }

--- a/apps/umve/glwidget.h
+++ b/apps/umve/glwidget.h
@@ -11,13 +11,13 @@
 #define UMVE_GL_WIDGET_HEADER
 
 #include <set>
-#include <QGLWidget>
+#include <QOpenGLWidget>
 #include <QMouseEvent>
 #include <QTimer>
 
 #include "ogl/context.h"
 
-class GLWidget : public QGLWidget
+class GLWidget : public QOpenGLWidget
 {
     Q_OBJECT
 
@@ -55,6 +55,7 @@ private:
     ogl::Context* context;
     int gl_width;
     int gl_height;
+    qreal device_pixel_ratio;
     bool cx_init;
     std::set<ogl::Context*> init_set;
     QTimer* repaint_timer;
@@ -77,8 +78,6 @@ GLWidget::sizeHint() const
 inline void
 GLWidget::repaint_gl (void)
 {
-    this->updateGL();
-    //this->repaint();
 }
 
 inline void

--- a/apps/umve/scene_inspect/scene_inspect.cc
+++ b/apps/umve/scene_inspect/scene_inspect.cc
@@ -186,7 +186,7 @@ SceneInspect::on_save_screenshot (void)
     if (filename.size() == 0)
         return;
 
-    QImage img = this->gl_widget->grabFrameBuffer(false);
+    QImage img = this->gl_widget->grabFramebuffer();
     bool success = img.save(filename);
     if (!success)
         QMessageBox::critical(this, "Cannot save image",

--- a/apps/umve/umve.cc
+++ b/apps/umve/umve.cc
@@ -15,7 +15,6 @@
 #include "ogl/opengl.h"
 
 #include <QApplication>
-#include <QGLFormat>
 
 #include "util/file_system.h"
 #include "util/arguments.h"
@@ -74,14 +73,16 @@ main (int argc, char** argv)
     }
 
     /* Set OpenGL version that Qt should use when creating a context.*/
-    QGLFormat fmt;
+    QSurfaceFormat fmt;
     fmt.setVersion(3, 3);
+    fmt.setDepthBufferSize(24);
+    fmt.setStencilBufferSize(8);
 #if defined(_WIN32)
-    fmt.setProfile(QGLFormat::CompatibilityProfile);
+    fmt.setProfile(QSurfaceFormat::CompatibilityProfile);
 #else
-    fmt.setProfile(QGLFormat::CoreProfile);
+    fmt.setProfile(QSurfaceFormat::CoreProfile);
 #endif
-    QGLFormat::setDefaultFormat(fmt);
+    QSurfaceFormat::setDefaultFormat(fmt);
 
     /* Create application. */
     set_qt_style("Cleanlooks");

--- a/apps/umve/viewinspect/viewinspect.cc
+++ b/apps/umve/viewinspect/viewinspect.cc
@@ -26,7 +26,7 @@
 #include "viewinspect.h"
 
 #if QT_VERSION >= 0x050000
-#   include <QWindow>
+#   include <QApplication>
 #endif
 
 ViewInspect::ViewInspect (QWidget* parent)
@@ -442,7 +442,8 @@ ViewInspect::display_byte_image (mve::ByteImage::ConstPtr img)
 
     QPixmap pixmap = QPixmap::fromImage(img_qimage);
 #if QT_VERSION >= 0x050000
-    pixmap.setDevicePixelRatio(this->windowHandle()->devicePixelRatio());
+    pixmap.setDevicePixelRatio(static_cast<QGuiApplication *>(
+        QApplication::instance())->devicePixelRatio());
 #endif
     this->scroll_image->set_pixmap(pixmap);
     this->action_zoom_fit->setEnabled(true);


### PR DESCRIPTION
- See [Qt Blog](http://blog.qt.io/blog/2014/09/10/qt-weekly-19-qopenglwidget/)
- Also fixes crashes on OSX