### PR TITLE
Clean up of Scene and View code

### DIFF
--- a/libs/mve/scene.cc
+++ b/libs/mve/scene.cc
@@ -85,10 +85,7 @@ Scene::cache_cleanup (void)
 std::size_t
 Scene::get_total_mem_usage (void)
 {
-    std::size_t ret = 0;
-    ret += this->get_view_mem_usage();
-    ret += this->get_bundle_mem_usage();
-    return ret;
+    return this->get_view_mem_usage() + this->get_bundle_mem_usage();
 }
 
 /* ---------------------------------------------------------------- */

--- a/libs/mve/scene.h
+++ b/libs/mve/scene.h
@@ -38,9 +38,6 @@ public:
     typedef std::vector<View::Ptr> ViewList;
 
 public:
-    /** Constructs an unmanaged scene, which should not be copied. */
-    Scene (void);
-
     /** Constructs a smart pointered scene. */
     static Scene::Ptr create (void);
     /** Constructs and loads a scene from the given directory. */
@@ -95,6 +92,9 @@ private:
     bool bundle_dirty;
 
 private:
+    /** Constructs an unmanaged scene, which should not be copied. */
+    Scene (void);
+
     void init_views (void);
 };
 
@@ -136,6 +136,20 @@ inline View::Ptr
 Scene::get_view_by_id (std::size_t id)
 {
     return (id < this->views.size() ? this->views[id] : View::Ptr());
+}
+
+inline void
+Scene::save_scene (void)
+{
+  this->save_bundle();
+  this->save_views();
+}
+
+inline bool
+Scene::is_dirty (void) const
+{
+  constexpr auto is_dirty = [](const View::Ptr& view) { return view && view->is_dirty(); };
+  return this->bundle_dirty || std::any_of(views.begin(), views.end(), is_dirty);
 }
 
 inline std::string const&

--- a/libs/mve/view.h
+++ b/libs/mve/view.h
@@ -294,11 +294,14 @@ private:
     void load_image_intern (ImageProxy* proxy, bool init_only);
     void save_image_intern (ImageProxy* proxy);
 
-    BlobProxy* find_blob_intern (std::string const& name);
     void initialize_blob (BlobProxy* proxy, bool update);
     ByteImage::Ptr load_blob (BlobProxy* proxy, bool update);
     void load_blob_intern (BlobProxy* proxy, bool init_only);
     void save_blob_intern (BlobProxy* proxy);
+
+    template<typename Container>
+    static
+    typename Container::iterator find_by_name(Container& collection, const std::string& name);
 
 protected:
     typedef std::vector<std::string> FilenameList;
@@ -409,6 +412,22 @@ View::get_float_image (std::string const& name)
 {
     return std::dynamic_pointer_cast<FloatImage>
         (this->get_image(name, IMAGE_TYPE_FLOAT));
+}
+
+inline bool
+View::has_blob (std::string const& name)
+{
+    return View::find_by_name(blobs, name) != blobs.end();
+}
+
+template<typename Container>
+typename Container::iterator
+View::find_by_name(Container& container, const std::string& name)
+{
+    using Element = decltype(container[0]);
+    const auto equal_name = [&name](Element& e)->bool { return e.name == name; };
+    auto found = std::find_if(container.begin(), container.end(), equal_name);
+    return found != container.end() ? found : container.end();
 }
 
 MVE_NAMESPACE_END


### PR DESCRIPTION
I'm trying making the code easier to read and maintain.
This PR reflects my initial work in that direction and changes only the Scene and View files:

- Replacing low level constructs by higher level constructs made available in C++11 where appropriate.
- Small changes to functions or new functions to reduce the number of repeating patterns in code.
- Commented out code has been removed. Most of these where  console output.

The only functional change is that the Scene(void) constructor has been made private, since
the documentation seems to suggest that it should not be used and it is not used anywhere outside of the class definition.

None of the touched code it hot code so there should not be any concerns about performance here.