### PR TITLE
Removal of raw Scene and View constructors from public API

### DIFF
--- a/apps/dmrecon/dmrecon.cc
+++ b/apps/dmrecon/dmrecon.cc
@@ -226,10 +226,10 @@ main (int argc, char** argv)
         conf.mvs.quiet = true;
 
     /* Load MVE scene. */
-    mve::Scene::Ptr scene = mve::Scene::create();
+    mve::Scene::Ptr scene;
     try
     {
-        scene->load_scene(conf.scene_path);
+        scene = mve::Scene::create(conf.scene_path);
         scene->get_bundle();
     }
     catch (std::exception& e)

--- a/apps/scene2pset/scene2pset.cc
+++ b/apps/scene2pset/scene2pset.cc
@@ -178,8 +178,7 @@ main (int argc, char** argv)
     mve::TriangleMesh::ConfidenceList& vconfs(pset->get_vertex_confidences());
 
     /* Load scene. */
-    mve::Scene::Ptr scene(mve::Scene::create());
-    scene->load_scene(conf.scenedir);
+    mve::Scene::Ptr scene = mve::Scene::create(conf.scenedir);
 
     /* Iterate over views and get points. */
     mve::Scene::ViewList& views(scene->get_views());

--- a/apps/sceneupgrade/sceneupgrade.cc
+++ b/apps/sceneupgrade/sceneupgrade.cc
@@ -226,9 +226,9 @@ convert_view (AppSettings const& conf, std::string const& fname)
     if (!util::fs::rename(fname.c_str(), fname_orig.c_str()))
         throw util::FileException(fname, std::strerror(errno));
 
-    mve::View view;
-    view.load_view_from_mve_file(fname_orig);
-    view.save_view_as(fname);
+    mve::View::Ptr view = mve::View::create();
+    view->load_view_from_mve_file(fname_orig);
+    view->save_view_as(fname);
 
     if (!conf.keep_original && !util::fs::unlink(fname_orig.c_str()))
     {

--- a/libs/mve/scene.h
+++ b/libs/mve/scene.h
@@ -86,6 +86,9 @@ public:
     /** Returns key point memory usage. */
     std::size_t get_bundle_mem_usage (void);
 
+protected:
+    Scene (void);
+
 private:
     std::string basedir;
     ViewList views;
@@ -93,7 +96,6 @@ private:
     bool bundle_dirty;
 
 private:
-    Scene (void);
     void init_views (void);
 };
 

--- a/libs/mve/scene.h
+++ b/libs/mve/scene.h
@@ -38,13 +38,11 @@ public:
     typedef std::vector<View::Ptr> ViewList;
 
 public:
-    /** Constructs an unmanaged scene, which should not be copied. */
-    Scene (void);
-
-    /** Constructs a smart pointered scene. */
-    static Scene::Ptr create (void);
     /** Constructs and loads a scene from the given directory. */
     static Scene::Ptr create (std::string const& path);
+
+    Scene(const Scene&) = delete;
+    Scene& operator=(const Scene&) = delete;
 
     /** Loads the scene from the given directory. */
     void load_scene (std::string const& base_path);
@@ -95,6 +93,7 @@ private:
     bool bundle_dirty;
 
 private:
+    Scene (void);
     void init_views (void);
 };
 
@@ -104,12 +103,6 @@ inline
 Scene::Scene (void)
     : bundle_dirty(false)
 {
-}
-
-inline Scene::Ptr
-Scene::create (void)
-{
-    return Scene::Ptr(new Scene);
 }
 
 inline Scene::Ptr

--- a/libs/mve/view.h
+++ b/libs/mve/view.h
@@ -139,6 +139,9 @@ public:
     static View::Ptr create (void);
     static View::Ptr create (std::string const& path);
 
+    View (const View&) = delete;
+    View operator= (const View&) = delete;
+
     /* --------------------- I/O interface -------------------- */
 
     /** Initializes the view from a directory. */
@@ -271,10 +274,7 @@ public:
     /** Prints a formatted list of internal data. */
     void debug_print (void);
 
-    /* ------------------ Convenience Functions ------------------- */
-
-
-public: // TODO: Make protected.
+protected:
     /** Creates an uninitialized view. */
     View (void);
 

--- a/tests/mve/gtest_view.cc
+++ b/tests/mve/gtest_view.cc
@@ -8,176 +8,179 @@
 
 TEST(ViewTest, AddSetHasRemoveTest)
 {
-    mve::View view;
+    mve::View::Ptr view = mve::View::create();
+    ASSERT_TRUE(view != nullptr);
 
     mve::ByteImage::Ptr image = mve::ByteImage::create(100, 100, 1);
-    EXPECT_FALSE(view.has_image("image"));
-    EXPECT_EQ(0, view.get_images().size());
-    EXPECT_NO_THROW(view.set_image(image, "image"));
-    EXPECT_EQ(1, view.get_images().size());
-    EXPECT_NO_THROW(view.set_image(image, "image"));
-    EXPECT_EQ(1, view.get_images().size());
-    EXPECT_TRUE(view.has_image("image"));
-    EXPECT_TRUE(view.remove_image("image"));
-    EXPECT_FALSE(view.remove_image("image"));
-    EXPECT_FALSE(view.has_image("image"));
-    EXPECT_EQ(0, view.get_images().size());
+    EXPECT_FALSE(view->has_image("image"));
+    EXPECT_EQ(0, view->get_images().size());
+    EXPECT_NO_THROW(view->set_image(image, "image"));
+    EXPECT_EQ(1, view->get_images().size());
+    EXPECT_NO_THROW(view->set_image(image, "image"));
+    EXPECT_EQ(1, view->get_images().size());
+    EXPECT_TRUE(view->has_image("image"));
+    EXPECT_TRUE(view->remove_image("image"));
+    EXPECT_FALSE(view->remove_image("image"));
+    EXPECT_FALSE(view->has_image("image"));
+    EXPECT_EQ(0, view->get_images().size());
 
     mve::ByteImage::Ptr blob = mve::ByteImage::create(100, 1, 1);
-    EXPECT_FALSE(view.has_blob("blob"));
-    EXPECT_EQ(0, view.get_blobs().size());
-    EXPECT_NO_THROW(view.set_blob(blob, "blob"));
-    EXPECT_EQ(1, view.get_blobs().size());
-    EXPECT_NO_THROW(view.set_blob(blob, "blob"));
-    EXPECT_EQ(1, view.get_blobs().size());
-    EXPECT_TRUE(view.has_blob("blob"));
-    EXPECT_TRUE(view.remove_blob("blob"));
-    EXPECT_FALSE(view.remove_blob("blob"));
-    EXPECT_FALSE(view.has_blob("blob"));
-    EXPECT_EQ(0, view.get_blobs().size());
+    EXPECT_FALSE(view->has_blob("blob"));
+    EXPECT_EQ(0, view->get_blobs().size());
+    EXPECT_NO_THROW(view->set_blob(blob, "blob"));
+    EXPECT_EQ(1, view->get_blobs().size());
+    EXPECT_NO_THROW(view->set_blob(blob, "blob"));
+    EXPECT_EQ(1, view->get_blobs().size());
+    EXPECT_TRUE(view->has_blob("blob"));
+    EXPECT_TRUE(view->remove_blob("blob"));
+    EXPECT_FALSE(view->remove_blob("blob"));
+    EXPECT_FALSE(view->has_blob("blob"));
+    EXPECT_EQ(0, view->get_blobs().size());
 }
 
 TEST(ViewTest, AddRemoveMemorySizeTest)
 {
     mve::ByteImage::Ptr image = mve::ByteImage::create(100, 100, 1);
     mve::ByteImage::Ptr blob = mve::ByteImage::create(100, 1, 1);
-    mve::View view;
-    view.set_image(image, "image");
-    EXPECT_EQ(100 * 100, view.get_byte_size());
-    view.set_blob(blob, "blob");
-    EXPECT_EQ(100 * 100 + 100, view.get_byte_size());
-    view.remove_image("image");
-    EXPECT_EQ(100, view.get_byte_size());
-    view.remove_blob("blob");
-    EXPECT_EQ(0, view.get_byte_size());
+    mve::View::Ptr view = mve::View::create();
+    view->set_image(image, "image");
+    EXPECT_EQ(100 * 100, view->get_byte_size());
+    view->set_blob(blob, "blob");
+    EXPECT_EQ(100 * 100 + 100, view->get_byte_size());
+    view->remove_image("image");
+    EXPECT_EQ(100, view->get_byte_size());
+    view->remove_blob("blob");
+    EXPECT_EQ(0, view->get_byte_size());
 }
 
 TEST(ViewTest, IsDirtyTest)
 {
     mve::ByteImage::Ptr image = mve::ByteImage::create(100, 100, 1);
     mve::ByteImage::Ptr blob = mve::ByteImage::create(100, 1, 1);
-    mve::View view1, view2, view3;
+    mve::View::Ptr view1 = mve::View::create(),
+                   view2 = mve::View::create(),
+                   view3 = mve::View::create();
 
-    EXPECT_FALSE(view1.is_dirty());
-    view1.set_image(image, "image");
-    EXPECT_TRUE(view1.is_dirty());
+    EXPECT_FALSE(view1->is_dirty());
+    view1->set_image(image, "image");
+    EXPECT_TRUE(view1->is_dirty());
 
-    EXPECT_FALSE(view2.is_dirty());
-    view2.set_blob(blob, "blob");
-    EXPECT_TRUE(view2.is_dirty());
+    EXPECT_FALSE(view2->is_dirty());
+    view2->set_blob(blob, "blob");
+    EXPECT_TRUE(view2->is_dirty());
 
-    EXPECT_FALSE(view3.is_dirty());
-    EXPECT_FALSE(view3.get_meta_data().is_dirty);
-    view3.set_value("view.key", "value");
-    EXPECT_TRUE(view3.is_dirty());
-    EXPECT_TRUE(view3.get_meta_data().is_dirty);
+    EXPECT_FALSE(view3->is_dirty());
+    EXPECT_FALSE(view3->get_meta_data().is_dirty);
+    view3->set_value("view.key", "value");
+    EXPECT_TRUE(view3->is_dirty());
+    EXPECT_TRUE(view3->get_meta_data().is_dirty);
 }
 
 TEST(ViewTest, CacheCleanupTest)
 {
     mve::ByteImage::Ptr image = mve::ByteImage::create(100, 1, 1);
     mve::ByteImage::Ptr blob = mve::ByteImage::create(100, 1, 1);
-    mve::View view;
-    view.set_image(image, "image");
-    view.set_blob(blob, "blob");
+    mve::View::Ptr view = mve::View::create();
+    view->set_image(image, "image");
+    view->set_blob(blob, "blob");
 
-    mve::View::ImageProxy const* image_proxy = view.get_image_proxy("image");
-    mve::View::BlobProxy const* blob_proxy = view.get_blob_proxy("blob");
+    mve::View::ImageProxy const* image_proxy = view->get_image_proxy("image");
+    mve::View::BlobProxy const* blob_proxy = view->get_blob_proxy("blob");
 
     EXPECT_TRUE(image_proxy->image != nullptr);
     EXPECT_TRUE(blob_proxy->blob != nullptr);
-    EXPECT_EQ(0, view.cache_cleanup());
+    EXPECT_EQ(0, view->cache_cleanup());
     EXPECT_TRUE(image_proxy->image != nullptr);
     EXPECT_TRUE(blob_proxy->blob != nullptr);
     image.reset();
     blob.reset();
     /* It is not cleaning anything because image and blob are dirty. */
-    EXPECT_EQ(0, view.cache_cleanup());
+    EXPECT_EQ(0, view->cache_cleanup());
     EXPECT_TRUE(image_proxy->image != nullptr);
     EXPECT_TRUE(blob_proxy->blob != nullptr);
 }
 
 TEST(ViewTest, KeyValueTest)
 {
-    mve::View view;
-    EXPECT_THROW(view.set_value("", ""), std::exception);
-    EXPECT_THROW(view.set_value("key", ""), std::exception);
-    EXPECT_NO_THROW(view.set_value("section.key", ""));
-    EXPECT_THROW(view.set_value("", "value"), std::exception);
-    EXPECT_NO_THROW(view.set_value("section.key", "value"));
+    mve::View::Ptr view = mve::View::create();
+    EXPECT_THROW(view->set_value("", ""), std::exception);
+    EXPECT_THROW(view->set_value("key", ""), std::exception);
+    EXPECT_NO_THROW(view->set_value("section.key", ""));
+    EXPECT_THROW(view->set_value("", "value"), std::exception);
+    EXPECT_NO_THROW(view->set_value("section.key", "value"));
 
-    EXPECT_THROW(view.get_value(""), std::exception);
-    EXPECT_THROW(view.get_value("key"), std::exception);
-    EXPECT_NO_THROW(view.get_value("section.key"));
+    EXPECT_THROW(view->get_value(""), std::exception);
+    EXPECT_THROW(view->get_value("key"), std::exception);
+    EXPECT_NO_THROW(view->get_value("section.key"));
 
-    EXPECT_EQ(view.get_value("section.key2"), "");
-    EXPECT_EQ(view.get_value("section.key"), "value");
-    view.delete_value("section.key");
-    EXPECT_EQ(view.get_value("section.key"), "");
+    EXPECT_EQ(view->get_value("section.key2"), "");
+    EXPECT_EQ(view->get_value("section.key"), "value");
+    view->delete_value("section.key");
+    EXPECT_EQ(view->get_value("section.key"), "");
 }
 
 TEST(ViewTest, GetByTypeTest)
 {
     mve::FloatImage::Ptr image = mve::FloatImage::create(10, 12, 1);
-    mve::View view;
+    mve::View::Ptr view = mve::View::create();
 
-    EXPECT_TRUE(view.get_image_proxy("image") == nullptr);
-    EXPECT_TRUE(view.get_image_proxy("image", mve::IMAGE_TYPE_FLOAT) == nullptr);
-    EXPECT_FALSE(view.has_image("image"));
-    EXPECT_FALSE(view.has_image("image", mve::IMAGE_TYPE_UNKNOWN));
-    EXPECT_FALSE(view.has_image("image", mve::IMAGE_TYPE_FLOAT));
+    EXPECT_TRUE(view->get_image_proxy("image") == nullptr);
+    EXPECT_TRUE(view->get_image_proxy("image", mve::IMAGE_TYPE_FLOAT) == nullptr);
+    EXPECT_FALSE(view->has_image("image"));
+    EXPECT_FALSE(view->has_image("image", mve::IMAGE_TYPE_UNKNOWN));
+    EXPECT_FALSE(view->has_image("image", mve::IMAGE_TYPE_FLOAT));
 
-    view.set_image(image, "image");
+    view->set_image(image, "image");
 
-    EXPECT_TRUE(view.get_image("image", mve::IMAGE_TYPE_UINT8) == nullptr);
-    EXPECT_EQ(image, view.get_image("image", mve::IMAGE_TYPE_FLOAT));
-    EXPECT_EQ(image, view.get_image("image", mve::IMAGE_TYPE_UNKNOWN));
-    EXPECT_EQ(image, view.get_image("image"));
+    EXPECT_TRUE(view->get_image("image", mve::IMAGE_TYPE_UINT8) == nullptr);
+    EXPECT_EQ(image, view->get_image("image", mve::IMAGE_TYPE_FLOAT));
+    EXPECT_EQ(image, view->get_image("image", mve::IMAGE_TYPE_UNKNOWN));
+    EXPECT_EQ(image, view->get_image("image"));
 
-    EXPECT_TRUE(view.get_image_proxy("image", mve::IMAGE_TYPE_FLOAT) != nullptr);
-    EXPECT_TRUE(view.get_image_proxy("image", mve::IMAGE_TYPE_UINT8) == nullptr);
-    EXPECT_TRUE(view.get_image_proxy("image", mve::IMAGE_TYPE_UNKNOWN) != nullptr);
-    EXPECT_TRUE(view.get_image_proxy("image") != nullptr);
+    EXPECT_TRUE(view->get_image_proxy("image", mve::IMAGE_TYPE_FLOAT) != nullptr);
+    EXPECT_TRUE(view->get_image_proxy("image", mve::IMAGE_TYPE_UINT8) == nullptr);
+    EXPECT_TRUE(view->get_image_proxy("image", mve::IMAGE_TYPE_UNKNOWN) != nullptr);
+    EXPECT_TRUE(view->get_image_proxy("image") != nullptr);
 
-    EXPECT_TRUE(view.has_image("image", mve::IMAGE_TYPE_UNKNOWN));
-    EXPECT_TRUE(view.has_image("image", mve::IMAGE_TYPE_FLOAT));
-    EXPECT_FALSE(view.has_image("image", mve::IMAGE_TYPE_UINT8));
-    EXPECT_TRUE(view.has_image("image"));
+    EXPECT_TRUE(view->has_image("image", mve::IMAGE_TYPE_UNKNOWN));
+    EXPECT_TRUE(view->has_image("image", mve::IMAGE_TYPE_FLOAT));
+    EXPECT_FALSE(view->has_image("image", mve::IMAGE_TYPE_UINT8));
+    EXPECT_TRUE(view->has_image("image"));
 }
 
 TEST(ViewTest, GetTypeImageTest)
 {
-    mve::View view;
+    mve::View::Ptr view = mve::View::create();
 
-    EXPECT_EQ(mve::FloatImage::Ptr(), view.get_float_image("image"));
-    EXPECT_EQ(mve::ByteImage::Ptr(), view.get_byte_image("image"));
+    EXPECT_EQ(mve::FloatImage::Ptr(), view->get_float_image("image"));
+    EXPECT_EQ(mve::ByteImage::Ptr(), view->get_byte_image("image"));
 
     mve::FloatImage::Ptr image = mve::FloatImage::create(10, 12, 1);
-    view.set_image(image, "image");
-    EXPECT_EQ(image, view.get_float_image("image"));
-    EXPECT_EQ(mve::ByteImage::Ptr(), view.get_byte_image("image"));
+    view->set_image(image, "image");
+    EXPECT_EQ(image, view->get_float_image("image"));
+    EXPECT_EQ(mve::ByteImage::Ptr(), view->get_byte_image("image"));
 
     mve::ByteImage::Ptr image2 = mve::ByteImage::create(10, 12, 1);
-    view.set_image(image2, "image2");
-    EXPECT_EQ(image2, view.get_byte_image("image2"));
-    EXPECT_EQ(mve::FloatImage::Ptr(), view.get_float_image("image2"));
+    view->set_image(image2, "image2");
+    EXPECT_EQ(image2, view->get_byte_image("image2"));
+    EXPECT_EQ(mve::FloatImage::Ptr(), view->get_float_image("image2"));
 }
 
 TEST(ViewTest, GetSetNameIdCamera)
 {
-    mve::View view;
-    EXPECT_EQ(view.get_name(), "");
-    view.set_name("testname");
-    EXPECT_EQ(view.get_name(), "testname");
+    mve::View::Ptr view = mve::View::create();
+    EXPECT_EQ(view->get_name(), "");
+    view->set_name("testname");
+    EXPECT_EQ(view->get_name(), "testname");
 
-    EXPECT_EQ(view.get_id(), -1);
-    view.set_id(12);
-    EXPECT_EQ(view.get_id(), 12);
+    EXPECT_EQ(view->get_id(), -1);
+    view->set_id(12);
+    EXPECT_EQ(view->get_id(), 12);
 
-    EXPECT_FALSE(view.is_camera_valid());
+    EXPECT_FALSE(view->is_camera_valid());
     mve::CameraInfo camera;
     camera.flen = 1.0f;
-    view.set_camera(camera);
-    EXPECT_TRUE(view.is_camera_valid());
-    EXPECT_EQ(view.get_camera().flen, camera.flen);
+    view->set_camera(camera);
+    EXPECT_TRUE(view->is_camera_valid());
+    EXPECT_EQ(view->get_camera().flen, camera.flen);
 }

--- a/tests/mve/gtest_view.cc
+++ b/tests/mve/gtest_view.cc
@@ -57,9 +57,9 @@ TEST(ViewTest, IsDirtyTest)
 {
     mve::ByteImage::Ptr image = mve::ByteImage::create(100, 100, 1);
     mve::ByteImage::Ptr blob = mve::ByteImage::create(100, 1, 1);
-    mve::View::Ptr view1 = mve::View::create(),
-                   view2 = mve::View::create(),
-                   view3 = mve::View::create();
+    mve::View::Ptr view1 = mve::View::create();
+    mve::View::Ptr view2 = mve::View::create();
+    mve::View::Ptr view3 = mve::View::create();
 
     EXPECT_FALSE(view1->is_dirty());
     view1->set_image(image, "image");


### PR DESCRIPTION
This is a rework of PR #337.
Refactor of Scene and View class code to make it easier to read and maintain:

- Replaced index based loops, with foreach loops where possible
- Removed raw constructors from public API
- Removed commented out code
- Removed unused control flow parameters of internal functions
- Replaced pointer parameters by reference parameters where nullptr would be illegal as argument.

No functional changes.