### PR TITLE
fix linux compilation error

### DIFF
--- a/apps/umve/scene_addins/addin_base.h
+++ b/apps/umve/scene_addins/addin_base.h
@@ -14,6 +14,7 @@
 #include <QMessageBox>
 
 #include "mve/mesh.h"
+#include "ogl/opengl.h"
 #include "ogl/context.h"
 
 #include "scene_addins/addin_state.h"


### PR DESCRIPTION
Fix building error on archlinux with gcc7.
Erro message:
>g++ -c -pipe -fPIC -fopenmp -O2 -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -std=gnu++11 -D_REENTRANT -Wall -W -fPIC -DQT_NO_DEBUG -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -I../../libs -isystem /usr/include/libdrm -isystem /usr/include/qt -isystem /usr/include/qt/QtOpenGL -isystem /usr/include/qt/QtWidgets -isystem /usr/include/qt/QtGui -isystem /usr/include/qt/QtCore -Ibuild -I/usr/lib/qt/mkspecs/linux-g++ -o build/addin_frusta_base.o scene_addins/addin_frusta_base.cc
In file included from ./scene_addins/addin_base.h:17:0,
                 from ./scene_addins/addin_aabb_creator.h:16,
                 from scene_addins/addin_aabb_creator.cc:15:
../../libs/ogl/context.h: In member function ‘void ogl::CameraContext<CTRL>::resize_impl(int, int)’
../../libs/ogl/context.h:192:5: error: there are no arguments to ‘glViewport’ that depend on a template parameter, so a declaration of ‘glViewport’ must be available [-fpermissive]
     glViewport(0, 0, this->width, this->height);
     ^~~~~~~~~~
../../libs/ogl/context.h:192:5: note: (if you use ‘-fpermissive’, G++ will accept your code, but allowing the use of an undeclared name is deprecated)