### PR TITLE
Add essential -mxxx build flag for successfull gcc6/linux compilation.

### DIFF
--- a/libs/sfm/Makefile
+++ b/libs/sfm/Makefile
@@ -2,7 +2,7 @@ MVE_ROOT := ../..
 TARGET := libmve_sfm.a
 include ${MVE_ROOT}/Makefile.inc
 
-CXXFLAGS += -I${MVE_ROOT}/libs ${OPENMP}
+CXXFLAGS += -I${MVE_ROOT}/libs ${OPENMP} -msse4.2
 LDLIBS += -lpng -ltiff -ljpeg
 
 SOURCES := $(wildcard [^_]*.cc)


### PR DESCRIPTION
Without -msse4.2 gcc7 complains about `target specific option mismatch `