### PR TITLE
OGL: report program linking errors

### DIFF
--- a/libs/ogl/shader_program.cc
+++ b/libs/ogl/shader_program.cc
@@ -96,6 +96,28 @@ ShaderProgram::compile_shader (GLuint shader_id, std::string const& code)
     }
 }
 
+void
+ShaderProgram::ensure_linked (void)
+{
+    if (this->need_to_link)
+    {
+        glLinkProgram(this->prog_id);
+        check_gl_error();
+        if (this->get_program_property(GL_LINK_STATUS) == GL_FALSE)
+        {
+            GLint log_size = this->get_program_property(GL_INFO_LOG_LENGTH);
+            if (log_size == 0)
+                throw util::Exception("Failed to link program (no message).");
+
+            std::string log;
+            log.append(log_size + 1, '\0');
+            glGetProgramInfoLog(this->prog_id, log_size + 1, nullptr, &log[0]);
+            throw util::Exception(log);
+        }
+        this->need_to_link = false;
+    }
+}
+
 /* ---------------------------------------------------------------- */
 
 bool

--- a/libs/ogl/shader_program.h
+++ b/libs/ogl/shader_program.h
@@ -300,17 +300,6 @@ ShaderProgram::unbind (void) const
     check_gl_error();
 }
 
-inline void
-ShaderProgram::ensure_linked (void)
-{
-    if (this->need_to_link)
-    {
-        glLinkProgram(this->prog_id);
-        check_gl_error();
-        this->need_to_link = false;
-    }
-}
-
 inline GLint
 ShaderProgram::get_program_property (int pname)
 {


### PR DESCRIPTION
Similar to the shader compilation error reporting, we should also show the errors when linking shaders. This PR implements this by retrieving the program info log in case the linking failed after the ``glLinkProgram`` call.