### PR TITLE
SFM: Always consider radial distortion

### DIFF
--- a/apps/sfmrecon/sfmrecon.cc
+++ b/apps/sfmrecon/sfmrecon.cc
@@ -378,6 +378,7 @@ sfm_reconstruct (AppSettings const& conf)
         else
         {
             incremental.triangulate_new_tracks(conf.min_views_per_track);
+            incremental.try_restore_tracks_for_views();
             std::cout << "Running full bundle adjustment..." << std::endl;
             incremental.bundle_adjustment_full();
             incremental.invalidate_large_error_tracks();

--- a/libs/sfm/bundler_common.h
+++ b/libs/sfm/bundler_common.h
@@ -11,6 +11,7 @@
 #define SFM_BUNDLER_COMMON_HEADER
 
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "math/vector.h"
@@ -51,6 +52,8 @@ struct Viewport
     FeatureSet features;
     /** Per-feature track ID, -1 if not part of a track. */
     std::vector<int> track_ids;
+    /** Backup map from features to tracks that were removed due to errors. */
+    std::unordered_map<int, int> backup_tracks;
 };
 
 /** The list of all viewports considered for bundling. */
@@ -162,6 +165,12 @@ load_prebundle_from_file (std::string const& filename,
 void
 load_survey_from_file (std::string const& filename,
     SurveyPointList* survey_points);
+
+/* ---------------------- Feature undistortion -------------------- */
+
+math::Vec2f
+undistort_feature (math::Vec2f const& f, double const k1, double const k2,
+    float const focal_length);
 
 /* ------------------------ Implementation ------------------------ */
 

--- a/libs/sfm/bundler_incremental.h
+++ b/libs/sfm/bundler_incremental.h
@@ -70,6 +70,8 @@ public:
     void find_next_views (std::vector<int>* next_views);
     /** Incrementally adds the given view to the bundle. */
     bool reconstruct_next_view (int view_id);
+    /** Restore tracks for views after intrinsics are optimized. */
+    void try_restore_tracks_for_views (void);
     /** Triangulates tracks without 3D position and at least N views. */
     void triangulate_new_tracks (int min_num_views);
     /** Deletes tracks with a large reprojection error. */


### PR DESCRIPTION
- Add an undistortion function for image features and use corrected features for track triangulation.
- If possible restore initial outlier tracks for viewports after intrinsics have been optimized.