### PR TITLE
Fixed intrinsic

### DIFF
--- a/libs/sfm/ba_types.h
+++ b/libs/sfm/ba_types.h
@@ -15,6 +15,7 @@ struct Camera
 
     double focal_length = 0.0;
     double distortion[2];
+    double principal_point[2];
     double translation[3];
     double rotation[9];
     bool is_constant = false;
@@ -41,6 +42,7 @@ inline
 Camera::Camera (void)
 {
     std::fill(this->distortion, this->distortion + 2, 0.0);
+    std::fill(this->principal_point, this->principal_point + 2, 0.0);
     std::fill(this->translation, this->translation + 3, 0.0);
     std::fill(this->rotation, this->rotation + 9, 0.0);
 }

--- a/libs/sfm/bundler_common.h
+++ b/libs/sfm/bundler_common.h
@@ -42,6 +42,8 @@ struct Viewport
     float focal_length;
     /** Radial distortion parameter. */
     float radial_distortion[2];
+    /** Principal point parameter. */
+    float principal_point[2];
 
     /** Camera pose for the viewport. */
     CameraPose pose;
@@ -201,6 +203,7 @@ Viewport::Viewport (void)
     : focal_length(0.0f)
 {
     std::fill(this->radial_distortion, this->radial_distortion + 2, 0.0f);
+    std::fill(this->principal_point, this->principal_point + 2, 0.0f);
 }
 
 inline bool

--- a/libs/sfm/bundler_init_pair.cc
+++ b/libs/sfm/bundler_init_pair.cc
@@ -256,9 +256,11 @@ InitialPair::compute_pose (CandidatePair const& candidate,
     /* Populate K-matrices. */
     Viewport const& view_1 = this->viewports->at(candidate.view_1_id);
     Viewport const& view_2 = this->viewports->at(candidate.view_2_id);
-    pose1->set_k_matrix(view_1.focal_length, 0.0, 0.0);
+    pose1->set_k_matrix(view_1.focal_length,
+        view_1.principal_point[0] - 0.5f, view_1.principal_point[1] - 0.5f);
     pose1->init_canonical_form();
-    pose2->set_k_matrix(view_2.focal_length, 0.0, 0.0);
+    pose2->set_k_matrix(view_2.focal_length,
+        view_2.principal_point[0] - 0.5f, view_2.principal_point[1] - 0.5f);
 
     /* Compute essential matrix from fundamental matrix (HZ (9.12)). */
     EssentialMatrix E = pose2->K.transposed() * fundamental * pose1->K;

--- a/libs/sfm/bundler_intrinsics.cc
+++ b/libs/sfm/bundler_intrinsics.cc
@@ -128,8 +128,10 @@ Intrinsics::init_from_views (mve::View::Ptr view, Viewport* viewport)
      *     needs to be processed elsewhere.
      */
     viewport->focal_length = camera.flen;
-    viewport->radial_distortion[0] = 0.0f;
-    viewport->radial_distortion[1] = 0.0f;
+    viewport->radial_distortion[0] = camera.dist[0];
+    viewport->radial_distortion[1] = camera.dist[1];
+    viewport->principal_point[0] = camera.ppoint[0];
+    viewport->principal_point[1] = camera.ppoint[1];
 }
 
 void

--- a/libs/sfm/camera_pose.h
+++ b/libs/sfm/camera_pose.h
@@ -46,6 +46,10 @@ public:
     void set_k_matrix (double flen, double px, double py);
     /** Returns the focal length as average of x and y focal length. */
     double get_focal_length (void) const;
+    /** Returns the principal point (x factor). */
+    double get_px (void) const;
+    /** Returns the principal point (y factor). */
+    double get_py (void) const;
     /** Returns the camera position (requires valid camera). */
     void fill_camera_pos (math::Vector<double, 3>* camera_pos) const;
     /** Returns true if K matrix is valid (non-zero focal length). */
@@ -95,6 +99,18 @@ inline double
 CameraPose::get_focal_length (void) const
 {
     return (this->K[0] + this->K[4]) / 2.0;
+}
+
+inline double
+CameraPose::get_px (void) const
+{
+    return this->K[2];
+}
+
+inline double
+CameraPose::get_py (void) const
+{
+    return this->K[5];
 }
 
 inline void


### PR DESCRIPTION
Implementation for fixed intrinsic in makescene and sfmrecon.

- makescene has a new parameter effective when importing images (-i): "--fixed-intrinsic f,k1,k2,px,py,pa". For instance "--fixed-intrinsic 0.8,0.1,-0.1,0.5,0.5,1.0". This will simply fill up the view's meta.ini
- load/store "radial_distortion" parameter in view's meta.ini
- sfmrecon with "--fixed-intrinsics --intrinsics-from-views" will now use focal_length and radial_distortion
- partial support for principal-point parameter (only forwarded, not used yet)

To be discussed/improved:
- how to embed principal point parameter in computations: undistort_feature() and invalidate_large_error_tracks()?
- do we need to forward also pixel_aspect?