### PR TITLE
Allow to initialize camera intrinsics in makescene

### DIFF
--- a/apps/makescene/makescene.cc
+++ b/apps/makescene/makescene.cc
@@ -899,9 +899,13 @@ import_images (AppSettings const& conf)
 
             tokenizer.split(conf.init_intrinsics, ',');
 
-            camera.flen = tokenizer.get_as<float>(0);
-            camera.dist[0] = tokenizer.get_as<float>(1);
-            camera.dist[1] = tokenizer.get_as<float>(2);
+            if (tokenizer.size() > 0)
+                camera.flen = tokenizer.get_as<float>(0);
+            if (tokenizer.size() >= 3)
+            {
+                camera.dist[0] = tokenizer.get_as<float>(1);
+                camera.dist[1] = tokenizer.get_as<float>(2);
+            }
             if (tokenizer.size() >= 5)
             {
                 camera.ppoint[0] = tokenizer.get_as<float>(3);

--- a/apps/makescene/makescene.cc
+++ b/apps/makescene/makescene.cc
@@ -960,7 +960,7 @@ main (int argc, char** argv)
         "specified, images are added to an existing scene.\n\n"
 
         "Initial camera intrinsics can be set in \"images-only\" mode: "
-        " normalized focal length (f), radial distortion coefficients (k1,k2), "
+        "normalized focal length (f), radial distortion coefficients (k1,k2), "
         "normalized principal point (ppx,ppy) and pixel aspect ratio (pa).");
     args.add_option('o', "original", false, "Import original images");
     args.add_option('b', "bundle-id", true, "Bundle ID (Photosynther and Bundler only) [0]");

--- a/apps/makescene/makescene.cc
+++ b/apps/makescene/makescene.cc
@@ -70,6 +70,7 @@ struct AppSettings
     bool images_only = false;
     bool append_images = false;
     int max_pixels = std::numeric_limits<int>::max();
+    std::string init_intrinsics;
 
     /* Computed values. */
     std::string bundle_path;
@@ -890,6 +891,27 @@ import_images (AppSettings const& conf)
         /* Add EXIF data to view if available. */
         add_exif_to_view(view, exif);
 
+        /* Set initial intrinsics */
+        if (!conf.init_intrinsics.empty())
+        {
+            util::Tokenizer tokenizer;
+            mve::CameraInfo camera;
+
+            tokenizer.split(conf.init_intrinsics, ',');
+
+            camera.flen = tokenizer.get_as<float>(0);
+            camera.dist[0] = tokenizer.get_as<float>(1);
+            camera.dist[1] = tokenizer.get_as<float>(2);
+            if (tokenizer.size() >= 5)
+            {
+                camera.ppoint[0] = tokenizer.get_as<float>(3);
+                camera.ppoint[1] = tokenizer.get_as<float>(4);
+            }
+            if (tokenizer.size() >= 6)
+                camera.paspect = tokenizer.get_as<float>(5);
+            view->set_camera(camera);
+        }
+
         /* Save view to disc. */
         std::string mve_fname = make_image_name(id);
 #pragma omp critical
@@ -935,13 +957,18 @@ main (int argc, char** argv)
 
         "With the \"images-only\" option, all images in the INPUT directory "
         "are imported without camera information. If \"append-images\" is "
-        "specified, images are added to an existing scene.");
+        "specified, images are added to an existing scene.\n\n"
+
+        "Initial camera intrinsics can be set in \"images-only\" mode: "
+        " normalized focal length (f), radial distortion coefficients (k1,k2), "
+        "normalized principal point (ppx,ppy) and pixel aspect ratio (pa).");
     args.add_option('o', "original", false, "Import original images");
     args.add_option('b', "bundle-id", true, "Bundle ID (Photosynther and Bundler only) [0]");
     args.add_option('k', "keep-invalid", false, "Keeps images with invalid cameras");
     args.add_option('i', "images-only", false, "Imports images from INPUT_DIR only");
     args.add_option('a', "append-images", false, "Appends images to an existing scene");
     args.add_option('m', "max-pixels", true, "Limit image size by iterative half-sizing");
+    args.add_option('c', "init-intrinsics", true, "Initial camera intrinsics (f,k1,k2,ppx,ppy,pa)");
     args.parse(argc, argv);
 
     /* Setup defaults. */
@@ -965,6 +992,8 @@ main (int argc, char** argv)
             conf.append_images = true;
         else if (i->opt->lopt == "max-pixels")
             conf.max_pixels = i->get_arg<int>();
+        else if (i->opt->lopt == "init-intrinsics")
+            conf.init_intrinsics = i->get_arg<std::string>();
         else
             throw std::invalid_argument("Unexpected option");
     }

--- a/libs/mve/view.cc
+++ b/libs/mve/view.cc
@@ -139,6 +139,8 @@ View::load_view_from_mve_file  (std::string const& filename)
             && tokens.size() >= 2 && tokens.size() <= 7)
         {
             this->set_value("camera.focal_length", tokens[1]);
+            if (tokens.size() > 3)
+                this->set_value("camera.radial_distortion", tokens.concat(2, 2));
             if (tokens.size() > 4)
                 this->set_value("camera.pixel_aspect", tokens[4]);
             if (tokens.size() > 6)
@@ -382,6 +384,9 @@ View::set_camera (CameraInfo const& camera)
     /* Re-generate the "camera" section. */
     this->set_value("camera.focal_length",
         util::string::get_digits(camera.flen, 10));
+    this->set_value("camera.radial_distortion",
+        util::string::get_digits(camera.dist[0], 10) + " "
+        + util::string::get_digits(camera.dist[1], 10));
     this->set_value("camera.pixel_aspect",
         util::string::get_digits(camera.paspect, 10));
     this->set_value("camera.principal_point",
@@ -592,6 +597,7 @@ View::load_meta_data (std::string const& path)
 
     /* Get camera data from key/value pairs. */
     std::string cam_fl = this->get_value("camera.focal_length");
+    std::string cam_dist = this->get_value("camera.radial_distortion");
     std::string cam_pa = this->get_value("camera.pixel_aspect");
     std::string cam_pp = this->get_value("camera.principal_point");
     std::string cam_rot = this->get_value("camera.rotation");
@@ -600,6 +606,12 @@ View::load_meta_data (std::string const& path)
     this->meta_data.camera = CameraInfo();
     if (!cam_fl.empty())
         this->meta_data.camera.flen = util::string::convert<float>(cam_fl);
+    if (!cam_dist.empty())
+    {
+        std::stringstream ss(cam_dist);
+        ss >> this->meta_data.camera.dist[0];
+        ss >> this->meta_data.camera.dist[1];
+    }
     if (!cam_pa.empty())
         this->meta_data.camera.paspect = util::string::convert<float>(cam_pa);
     if (!cam_pp.empty())
@@ -692,7 +704,7 @@ View::populate_images_and_blobs (std::string const& path)
             proxy.name = name;
             this->blobs.push_back(proxy);
         }
-        else
+        else if (ext4 != ".ply") // silently ignore ply files
         {
             std::cerr << "View: Unrecognized extension "
                 << file.name << ", skipping." << std::endl;


### PR DESCRIPTION
Implementation for fixed intrinsics in makescene.

- makescene has a new parameter effective when importing images (with -i): "--init-intrinsics f,k1,k2,ppx,ppy,pa". For instance "--init-intrinsics 0.8,0.1,-0.1,0.5,0.5,1.0". This will simply fill up the view's meta.ini
-  load/store "radial_distortion" parameter in view's meta.ini