### PR TITLE
Use principal point in feature normalization and radial distortion in BA

### DIFF
--- a/libs/sfm/bundler_common.h
+++ b/libs/sfm/bundler_common.h
@@ -42,6 +42,8 @@ struct Viewport
     float focal_length;
     /** Radial distortion parameter. */
     float radial_distortion[2];
+    /** Principal point parameter. */
+    float principal_point[2];
 
     /** Camera pose for the viewport. */
     CameraPose pose;
@@ -201,6 +203,7 @@ Viewport::Viewport (void)
     : focal_length(0.0f)
 {
     std::fill(this->radial_distortion, this->radial_distortion + 2, 0.0f);
+    std::fill(this->principal_point, this->principal_point + 2, 0.5f);
 }
 
 inline bool

--- a/libs/sfm/bundler_features.cc
+++ b/libs/sfm/bundler_features.cc
@@ -67,7 +67,8 @@ Features::compute (mve::Scene::Ptr scene, ViewportList* viewports)
         Viewport* viewport = &viewports->at(i);
         viewport->features.set_options(this->opts.feature_options);
         viewport->features.compute_features(image);
-        viewport->features.normalize_feature_positions();
+        viewport->features.normalize_feature_positions(
+            viewport->principal_point[0], viewport->principal_point[1]);
 
 #pragma omp critical
         {

--- a/libs/sfm/bundler_intrinsics.cc
+++ b/libs/sfm/bundler_intrinsics.cc
@@ -115,21 +115,12 @@ Intrinsics::init_from_views (mve::View::Ptr view, Viewport* viewport)
         return;
     }
 
-    /*
-     * The current implementation sets the focal length from the view
-     * but uses defaults for radial distortion and principle point.
-     *
-     * TODO: Also use pre-defined radial distortion and principal point.
-     *
-     * RD: To support radial distortion, read "camera.radial_distortion"
-     *     from the view and set it here. It must be in PBA format.
-     * PP: To support principle point, use CameraInfo::ppoint and set it in
-     *     the viewport. Note that a new field is required for this, and it
-     *     needs to be processed elsewhere.
-     */
+    /* Sets the focal length, radial distortion and principal point from the view. */
     viewport->focal_length = camera.flen;
-    viewport->radial_distortion[0] = 0.0f;
-    viewport->radial_distortion[1] = 0.0f;
+    viewport->radial_distortion[0] = camera.dist[0];
+    viewport->radial_distortion[1] = camera.dist[1];
+    viewport->principal_point[0] = camera.ppoint[0];
+    viewport->principal_point[1] = camera.ppoint[1];
 }
 
 void

--- a/libs/sfm/camera_pose.h
+++ b/libs/sfm/camera_pose.h
@@ -28,6 +28,9 @@ SFM_NAMESPACE_BEGIN
  *   K = | 0  f  py |    and the principal point px and py.
  *       | 0  0   1 |
  *
+ * As the feature coordinates are normalized before pose estimation, the
+ * principal point (px, py) is set to 0.0.
+ *
  * For pose estimation, the calibration matrix is assumed to be known. This
  * might not be the case, but even a good guess of the focal length and the
  * principal point set to the image center can produce reasonably good

--- a/libs/sfm/feature_set.cc
+++ b/libs/sfm/feature_set.cc
@@ -40,7 +40,7 @@ FeatureSet::compute_features (mve::ByteImage::Ptr image)
 }
 
 void
-FeatureSet::normalize_feature_positions (void)
+FeatureSet::normalize_feature_positions (float px, float py)
 {
     /* Normalize image coordinates. */
     float const fwidth = static_cast<float>(this->width);
@@ -49,8 +49,8 @@ FeatureSet::normalize_feature_positions (void)
     for (std::size_t i = 0; i < this->positions.size(); ++i)
     {
         math::Vec2f& pos = this->positions[i];
-        pos[0] = (pos[0] + 0.5f - fwidth / 2.0f) / fnorm;
-        pos[1] = (pos[1] + 0.5f - fheight / 2.0f) / fnorm;
+        pos[0] = (pos[0] + 0.5f - fwidth * px) / fnorm;
+        pos[1] = (pos[1] + 0.5f - fheight * py) / fnorm;
     }
 }
 

--- a/libs/sfm/feature_set.h
+++ b/libs/sfm/feature_set.h
@@ -54,7 +54,7 @@ public:
     void compute_features (mve::ByteImage::Ptr image);
 
     /** Normalizes the features positions w.r.t. the image dimensions. */
-    void normalize_feature_positions (void);
+    void normalize_feature_positions (float px, float py);
 
     /** Clear descriptor data. */
     void clear_descriptors (void);


### PR DESCRIPTION
The second PR related to integrating fixed intrinsics in BA.

- Principal point is used in feature normalization (defaults to 0.5)
- Radial distortion is used in BA, either as a starting point or as a fixed parameter (defaults to 0.0)