### PR TITLE
Allow MVE to run on older hardware

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,7 +1,7 @@
 # Default values.
 CXX ?= g++
 CXXWARNINGS ?= -Wall -Wextra -Wundef -pedantic
-CXXINTRINSICS ?= -msse2 -msse3 -msse4 -mpopcnt
+CXXINTRINSICS ?= -march=native
 CXXFEATURES ?= -funsafe-math-optimizations -fno-math-errno -std=c++11
 CXXFLAGS ?= ${CXXWARNINGS} ${CXXINTRINSICS} ${CXXFEATURES} -g -O3
 


### PR DESCRIPTION
Hello there :hand:

Currently the default build settings will force MVE to be compiled using instruction sets that sometimes are not available to the CPU. Unless I've missed something, wouldn't specifying `march=native` take care of selecting the best available set of instructions for the user?

https://stackoverflow.com/questions/10686638/whats-the-differrence-among-cflgs-sse-options-of-msse-msse2-mssse3-msse4
https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html

I thought I'd open a PR, but if I've overlooked something please feel free to close it.

Thanks!
