### PR TITLE
Fixed white space noah bundler import bug

### DIFF
--- a/apps/makescene/makescene.cc
+++ b/apps/makescene/makescene.cc
@@ -106,9 +106,8 @@ read_noah_imagelist (std::string const& filename, StringVector& files)
 
     while (true)
     {
-        std::string file, dummy;
-        in >> file;
-        std::getline(in, dummy);
+        std::string file;
+        std::getline(in, file);
         if (file.empty())
             break;
         files.push_back(file);


### PR DESCRIPTION
Hello :hand: 

This is a minor fix for `makescene` for cases when a Bundler dataset has spaces in the filenames of images (for example, `DJI 0018.JPG`). The root cause is that >> stops at the first white space or new line, whichever comes first. `makescene` then fails with:

```
Creating output directories...
Saving bundle file...
Writing bundle (4 cameras, xxx features): /path/to/output/synth_0.out...
Processing view view_0000.mve...
Error loading: /path/to/images/DJI
```

This code change simply uses std::getline, which reads the entire line, until it finds a new line character, skips the new line character and continues with the next line. https://en.cppreference.com/w/cpp/string/basic_string/getline

Test case to reproduce: [testcase.zip](https://github.com/simonfuhrmann/mve/files/2920462/testcase.zip)

Invoke with `makescene ./mve ./output`

Please let me know if further changes are needed. :+1: 
