### PR TITLE
Added mutex lock to View::save_view() and View::cache_clean()

### DIFF
--- a/libs/mve/view.cc
+++ b/libs/mve/view.cc
@@ -225,6 +225,8 @@ View::save_view_as (std::string const& user_path)
 int
 View::save_view (void)
 {
+    std::lock_guard<std::mutex> lock(this->sv_cc_mutex);
+
     if (this->path.empty())
         throw std::runtime_error("View not initialized");
 
@@ -305,6 +307,8 @@ View::is_dirty (void) const
 int
 View::cache_cleanup (void)
 {
+    std::lock_guard<std::mutex> lock(this->sv_cc_mutex);
+        
     int released = 0;
     for (std::size_t i = 0; i < this->images.size(); ++i)
     {

--- a/libs/mve/view.h
+++ b/libs/mve/view.h
@@ -47,6 +47,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <mutex>
 
 #include "mve/defines.h"
 #include "mve/camera.h"
@@ -300,6 +301,7 @@ private:
     void load_blob_intern (BlobProxy* proxy, bool init_only);
     void save_blob_intern (BlobProxy* proxy);
 
+    std::mutex sv_cc_mutex; // protect save_view and cache_clean
 protected:
     typedef std::vector<std::string> FilenameList;
 


### PR DESCRIPTION
This is a proposed fix for #476 and #323. The rationale for adding a mutex on save_view and cache_clean is that `cache_clean` seems to be the function responsible for deallocating the pointers too early in certain race condition instances, while the corrupted pointers show up in `save_image_intern`, which is only ever called by `save_view`.

I don't know if this is the best way to fix it, but seems to work. The verification has been done by running the code modified for triggering the fault (https://github.com/pierotofy/mve/tree/segfaultpoc) (`./test1.sh` contains code to re-run `dmrecon` until it fails). Before this patch the code would fail before ~5-10 iterations. After this patch the code seems to have stopped seg faulting.

Feedback is welcome. :clinking_glasses: 