### PR TITLE
Add Libexecinfo flag for alpine + create Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM alpine:3.10
+
+COPY . /mve
+
+RUN apk add --no-cache \
+    make \
+    g++ \
+    jpeg-dev \
+    libpng-dev \
+    tiff-dev \
+    mesa-dev \
+    libexecinfo-dev
+
+RUN echo $(ls /usr/include) \
+    && cd /mve \
+    && make all
+    

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,14 @@
-FROM alpine:3.10
+ARG ALPINE_VERSION=3.10
+FROM alpine:${ALPINE_VERSION}
 
 COPY . /mve
 
 RUN apk add --no-cache \
-    make \
-    g++ \
-    jpeg-dev \
-    libpng-dev \
-    tiff-dev \
-    mesa-dev \
-    libexecinfo-dev
-
-RUN echo $(ls /usr/include) \
+        make \
+        g++ \
+        jpeg-dev \
+        libpng-dev \
+        tiff-dev \
+        mesa-dev \
     && cd /mve \
     && make all
-    

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -16,9 +16,10 @@ ifeq (${UNAME},Darwin)
     OPENMP =
 else
     ifeq (${UNAME},Linux)
+        # musl compiler is missing libexec, skip on alpine
         ALPINE=$(wildcard /etc/alpine-release)
         ifneq (${ALPINE},)
-            LDLIBS += -lexecinfo
+            CXXFLAGS += -DSYSTEM_SKIP_LIBEXEC
         endif
     endif
 endif

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -14,6 +14,13 @@ CXXFLAGS += -pthread
 UNAME = $(shell uname)
 ifeq (${UNAME},Darwin)
     OPENMP =
+else
+    ifeq (${UNAME},Linux)
+        ALPINE=$(wildcard /etc/alpine-release)
+        ifneq (${ALPINE},)
+            LDLIBS += -lexecinfo
+        endif
+    endif
 endif
 
 COMPILE.cc = ${CXX} ${CXXFLAGS} ${CPPFLAGS} -c

--- a/libs/util/system.cc
+++ b/libs/util/system.cc
@@ -10,7 +10,7 @@
 #include <iostream>
 #include <cstdlib>
 #include <csignal>
-#if defined(__GNUC__) && !defined(_WIN32) && !defined(__CYGWIN__)
+#if defined(__GNUC__) && !defined(_WIN32) && !defined(__CYGWIN__) && !defined(SYSTEM_SKIP_LIBEXEC)
 #   include <execinfo.h> // ::backtrace
 #endif
 
@@ -51,7 +51,7 @@ signal_segfault_handler (int code)
 void
 print_stack_trace (void)
 {
-#if defined(__GNUC__) && !defined(_WIN32) &&  !defined(__CYGWIN__)
+#if defined(__GNUC__) && !defined(_WIN32) &&  !defined(__CYGWIN__) && !defined(SYSTEM_SKIP_LIBEXEC)
     /* Get stack pointers for all frames on the stack. */
     void *array[32];
     int const size = ::backtrace(array, 32);


### PR DESCRIPTION
Alpine doesn't include the backtrace functionality of glibc, which is
used in libs/util/system.cc. Libexecinfo provides the missing function
symbols for Alpine and FreeBSD distros. Adding a check in Makefile.inc
for /etc/alpine-release will determine if the library needs to be
linked.

Provide a Dockerfile to validate the build on Alpine. The Dockerfile
provides a minimal set of dependencies needed for compilation.