### PR TITLE
Check for GLIBC rather than GNUC for compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+ARG ALPINE_VERSION=3.10
+FROM alpine:${ALPINE_VERSION}
+
+COPY . /mve
+
+RUN apk add --no-cache \
+        make \
+        g++ \
+        jpeg-dev \
+        libpng-dev \
+        tiff-dev \
+        mesa-dev \
+    && cd /mve \
+    && mkdir bin \
+    && make all
+

--- a/libs/util/system.cc
+++ b/libs/util/system.cc
@@ -10,7 +10,7 @@
 #include <iostream>
 #include <cstdlib>
 #include <csignal>
-#if defined(__GNUC__) && !defined(_WIN32) && !defined(__CYGWIN__)
+#if defined(__GLIBC__) && !defined(_WIN32) && !defined(__CYGWIN__)
 #   include <execinfo.h> // ::backtrace
 #endif
 
@@ -51,7 +51,7 @@ signal_segfault_handler (int code)
 void
 print_stack_trace (void)
 {
-#if defined(__GNUC__) && !defined(_WIN32) &&  !defined(__CYGWIN__)
+#if defined(__GLIBC__) && !defined(_WIN32) &&  !defined(__CYGWIN__)
     /* Get stack pointers for all frames on the stack. */
     void *array[32];
     int const size = ::backtrace(array, 32);


### PR DESCRIPTION
The current compatibility checks in the libs/util/system.cc
check for the __GNUC__ flag when deciding whether to include
the execinfo.h header and backtrace functionalityt. The
__GNUC__ flag returns true for distros that do not inlude glibc
which will cause compilation issues for musl libc.

The check now looks for __GLIBC__ and will properly exclude the
functionality from distros using a different libc implementation.

Also a Dockerfile is included which can be used to validate builds
on musl based distros such as Alpine.