### PR TITLE
Added unsigned short vector types

### DIFF
--- a/libs/math/vector.h
+++ b/libs/math/vector.h
@@ -72,6 +72,12 @@ typedef Vector<std::size_t,3> Vec3st;
 typedef Vector<std::size_t,4> Vec4st;
 typedef Vector<std::size_t,5> Vec5st;
 typedef Vector<std::size_t,6> Vec6st;
+typedef Vector<unsigned short,1> Vec1us;
+typedef Vector<unsigned short,2> Vec2us;
+typedef Vector<unsigned short,3> Vec3us;
+typedef Vector<unsigned short,4> Vec4us;
+typedef Vector<unsigned short,5> Vec5us;
+typedef Vector<unsigned short,6> Vec6us;
 
 /**
  * Vector class for arbitrary dimensions and types.


### PR DESCRIPTION
This PR defines vector types of unsigned short (which are missing).

To provide some context on why I'm suggesting to add these, I'm working on expanding mvs-texturing to support 16bit textures (https://github.com/pierotofy/mvs-texturing/tree/depth) (which require this data type for certain inputs). This vector type is not directly used by MVE apps, but might be useful for others looking to use MVE as a library.