### PR TITLE
fix not supported file system cases

### DIFF
--- a/libs/util/file_system.cc
+++ b/libs/util/file_system.cc
@@ -588,6 +588,12 @@ Directory::scan (std::string const& path)
         this->back().path = path;
         this->back().name = ep->d_name;
         this->back().is_dir = (ep->d_type == DT_DIR);
+        if (ep->d_type == DT_UNKNOWN)
+        {
+            struct stat path_stat;
+            if (::stat(join_path(path, ep->d_name).c_str(), &path_stat) >= 0)
+                this->back().is_dir = S_ISDIR(path_stat.st_mode);
+        }
     }
     ::closedir(dp);
 #endif


### PR DESCRIPTION
from documentation for function `readdir`:
```
Currently, only some filesystems (among them: Btrfs, ext2, ext3,
and ext4) have full support for returning the file type in d_type.
All applications must properly handle a return DT_UNKNOWN
```
To avoid problems with not supported file system, `is_dir` flag additionally  computed via function `stat`, which don't have same constraints.

In my case, `DT_UNKNOWN` was given from `readdir`, if sub-folder is mounted via `sshfs`.