### PR TITLE
Fix fill_calibration and fill_inverse_calibration

### DIFF
--- a/libs/mve/camera.cc
+++ b/libs/mve/camera.cc
@@ -124,19 +124,9 @@ CameraInfo::set_transformation (float const* mat)
 void
 CameraInfo::fill_calibration (float* mat, float width, float height) const
 {
-    float dim_aspect = width / height;
-    float image_aspect = dim_aspect * this->paspect;
-    float ax, ay;
-    if (image_aspect < 1.0f) /* Portrait. */
-    {
-        ax = this->flen * height / this->paspect;
-        ay = this->flen * height;
-    }
-    else /* Landscape. */
-    {
-        ax = this->flen * width;
-        ay = this->flen * width * this->paspect;
-    }
+    size_t max_extent = std::max(width, height);
+    float ax = this->flen * max_extent;
+    float ay = ax * this->paspect;
 
     mat[0] =   ax; mat[1] = 0.0f; mat[2] = width * this->ppoint[0];
     mat[3] = 0.0f; mat[4] =   ay; mat[5] = height * this->ppoint[1];
@@ -149,19 +139,9 @@ void
 CameraInfo::fill_gl_projection (float* mat, float width, float height,
     float znear, float zfar) const
 {
-    float dim_aspect = width / height;
-    float image_aspect = dim_aspect * this->paspect;
-    float ax, ay;
-    if (image_aspect < 1.0f) /* Portrait. */
-    {
-        ax = this->flen / image_aspect;
-        ay = this->flen;
-    }
-    else /* Landscape */
-    {
-        ax = this->flen;
-        ay = this->flen * image_aspect;
-    }
+    size_t max_extent = std::max(width, height);
+    float ax = this->flen * max_extent;
+    float ay = ax * this->paspect;
 
     std::fill(mat, mat + 16, 0.0f);
 
@@ -180,19 +160,9 @@ void
 CameraInfo::fill_inverse_calibration (float* mat,
     float width, float height) const
 {
-    float dim_aspect = width / height;
-    float image_aspect = dim_aspect * this->paspect;
-    float ax, ay;
-    if (image_aspect < 1.0f) /* Portrait. */
-    {
-        ax = this->flen * height / this->paspect;
-        ay = this->flen * height;
-    }
-    else /* Landscape. */
-    {
-        ax = this->flen * width;
-        ay = this->flen * width * this->paspect;
-    }
+    size_t max_extent = std::max(width, height);
+    float ax = this->flen * max_extent;
+    float ay = ax * this->paspect;
 
     mat[0] = 1.0f / ax; mat[1] = 0.0f; mat[2] = -width * this->ppoint[0] / ax;
     mat[3] = 0.0f; mat[4] = 1.0f / ay; mat[5] = -height * this->ppoint[1] / ay;


### PR DESCRIPTION
When running an experiment with some satellite images, I observed that the `fill_calibration` and `fill_inverse_calibration` methods are (probably) incorrect. 
I tried to compute a dense point cloud using some depth maps imported with the recently added Colmap-Importer. The fused result showed that the triangulation of the different depth maps have a huge displacement. The following image shows an example. The mesh in green is reconstructed with Colmap and serves as reference. 

![fused_result_incorrect_with_mesh](https://user-images.githubusercontent.com/19491335/92114431-1c8b1680-edf1-11ea-8833-7230c201181e.jpg)

The reason for that is that the pinhole camera models used to approximate the pusbroom cameras of satellites are very special. They potentially have dramatically different focal length values `fx` and `fy` as well as strange principal points `cx` and `cy`. Therefore, they are suitable for testing the pipeline for cases with extreme values. In addition, already small errors in the camera models / poses result in large reconstruction point cloud errors, since the satellites are thousands of kilometers away from the reconstructed point cloud.

Note, when running the same experiments with "standard" camera models (i.e. `fx` almost identical to `fy`, `cx` and `cy` close to the image center), I did not observe cases like this. 

The following image shows the fused point cloud of all 50 cameras using the changes of this PR.
![fused_result_correct](https://user-images.githubusercontent.com/19491335/92115467-c15a2380-edf2-11ea-83ca-9c162520b336.jpg)

The next image shows an overlay with the green mesh. As one can see, the differences are very small (i.e. the pose and shape of the fused point cloud and the mesh are almost identical)
![fused_result_correct_with_mesh](https://user-images.githubusercontent.com/19491335/92115533-dcc52e80-edf2-11ea-95e3-193691200c64.jpg)

Here, a final textured mesh using the the different pipeline components of MVE except of the Structure from Motion and the Depth Map computation (for both steps it is necessary to use [this Colmap fork](https://github.com/Kai-46/VisSatSatelliteStereo) to address specific properties of satellite images). 

![textured_mesh](https://user-images.githubusercontent.com/19491335/92116923-c324e680-edf4-11ea-9189-b26eff5cb4f6.jpg)

I'm aware that this is a fundamental change, but I guess that the experiments above nicely show that this change is correct. Any second thoughts on this?