### PR TITLE
Fix travis build issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ before_script:
    - wget https://github.com/google/googletest/archive/master.zip -O /tmp/gtest.zip
    - unzip /tmp/gtest.zip
    - export GTEST_PATH=$PWD/googletest-master
-   - sed -i 's%"$<BUILD_INTERFACE:${gtest_build_include_dirs}>"%"$<BUILD_INTERFACE:${gtest_SOURCE_DIR}/include>"\n    "$<BUILD_INTERFACE:${gtest_SOURCE_DIR}>"%g' $GTEST_PATH/googletest/CMakeLists.txt
    - mkdir $GTEST_PATH/build
    - pushd $GTEST_PATH/build
    - cmake ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ sudo: false
 branches:
    only:
      - master
+     - travis_test
 
 before_install:
    - if [ "$CXX" = "g++" ]; then export CXX="g++-6"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
    - wget https://github.com/google/googletest/archive/master.zip -O /tmp/gtest.zip
    - unzip /tmp/gtest.zip
    - export GTEST_PATH=$PWD/googletest-master
-   - sed -i 's%"$<BUILD_INTERFACE:${gtest_build_include_dirs}>"%"$<BUILD_INTERFACE:${gtest_SOURCE_DIR}/include>"\n    "$<BUILD_INTERFACE:${gtest_SOURCE_DIR}>"%g' $GTEST_PATH/CMakeLists.txt
+   - sed -i 's%"$<BUILD_INTERFACE:${gtest_build_include_dirs}>"%"$<BUILD_INTERFACE:${gtest_SOURCE_DIR}/include>"\n    "$<BUILD_INTERFACE:${gtest_SOURCE_DIR}>"%g' $GTEST_PATH/googletest/CMakeLists.txt
    - mkdir $GTEST_PATH/build
    - pushd $GTEST_PATH/build
    - cmake ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ addons:
 before_script:
    - wget https://github.com/google/googletest/archive/master.zip -O /tmp/gtest.zip
    - unzip /tmp/gtest.zip
-   - export GTEST_PATH=$PWD/googletest-master/googletest
+   - export GTEST_PATH=$PWD/googletest-master
    - mkdir $GTEST_PATH/build
    - pushd $GTEST_PATH/build
    - cmake ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_script:
    - wget https://github.com/google/googletest/archive/master.zip -O /tmp/gtest.zip
    - unzip /tmp/gtest.zip
    - export GTEST_PATH=$PWD/googletest-master
+   - sed -i 's%"$<BUILD_INTERFACE:${gtest_build_include_dirs}>"%"$<BUILD_INTERFACE:${gtest_SOURCE_DIR}/include>"\n    "$<BUILD_INTERFACE:${gtest_SOURCE_DIR}>"%g' $GTEST_PATH/CMakeLists.txt
    - mkdir $GTEST_PATH/build
    - pushd $GTEST_PATH/build
    - cmake ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ sudo: false
 branches:
    only:
      - master
-     - travis_test
 
 before_install:
    - if [ "$CXX" = "g++" ]; then export CXX="g++-6"; fi

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,7 +5,7 @@ vpath libgtest_main.a ${GTEST_PATH}/build/lib
 vpath libgtest.a ${GTEST_PATH}/build/lib
 
 SOURCES = $(wildcard math/gtest_*.cc) $(wildcard mve/gtest_*.cc) $(wildcard sfm/gtest_*.cc) $(wildcard util/gtest_*.cc) $(wildcard fssr/gtest_*.cc)
-INCLUDES = -I${MVE_ROOT}/libs -I${GTEST_PATH}/include
+INCLUDES = -I${MVE_ROOT}/libs -I${GTEST_PATH}/googletest/include
 CXXWARNINGS = -Wall -Wextra -pedantic -Wno-sign-compare
 CXXFLAGS = -std=c++11 -pthread ${CXXWARNINGS} ${INCLUDES}
 LDLIBS += -lpng -ltiff -ljpeg


### PR DESCRIPTION
I've noticed that [recent travis builds](https://travis-ci.org/github/simonfuhrmann/mve/builds) failed for a reason that has nothing to do with the code.

After some searching, I've found that [cmake should be run in googletest's home directory, not googletest/googletest](https://github.com/google/googletest/issues/2882#issuecomment-753471115).

So this PR revise `GTEST_PATH` and update the include directory in `tests/Makefile` accordingly.

You can see that these changes make travis build successfully: https://travis-ci.org/github/keineahnung2345/mve/jobs/757523169.