### PR TITLE
Check extensions before loading images/headers

### DIFF
--- a/libs/mve/image_io.cc
+++ b/libs/mve/image_io.cc
@@ -56,33 +56,49 @@ MVE_IMAGE_NAMESPACE_BEGIN
 ByteImage::Ptr
 load_file (std::string const& filename)
 {
+    using namespace util::string;
+    std::string fext4 = lowercase(right(filename, 4));
+    std::string fext5 = lowercase(right(filename, 5));
+
     try
     {
 #ifndef MVE_NO_PNG_SUPPORT
-        try
-        { return load_png_file(filename); }
-        catch (util::FileException& e) { throw; }
-        catch (util::Exception& e) {}
+        if (fext4 == ".png") {
+            try
+            { return load_png_file(filename); }
+            catch (util::FileException& e) { throw; }
+            catch (util::Exception& e) {}
+        }
 #endif
 
 #ifndef MVE_NO_JPEG_SUPPORT
-        try
-        { return load_jpg_file(filename); }
-        catch (util::FileException& e) { throw; }
-        catch (util::Exception& e) {}
+        if (fext4 == ".jpg" || fext5 == ".jpeg") {
+            try
+            {
+                return load_jpg_file(filename);
+            }
+            catch (util::FileException& e) { throw; }
+            catch (util::Exception& e) {}
+        }
 #endif
 
 #ifndef MVE_NO_TIFF_SUPPORT
-        try
-        { return load_tiff_file(filename); }
-        catch (util::FileException& e) { throw; }
-        catch (util::Exception& e) {}
+        if (fext4 == ".tif" || fext5 == ".tiff") {
+            try
+            { return load_tiff_file(filename); }
+            catch (util::FileException& e) { throw; }
+            catch (util::Exception& e) {}
+        }
 #endif
 
-        try
-        { return load_ppm_file(filename); }
-        catch (util::FileException& e) { throw; }
-        catch (util::Exception& e) {}
+        if (fext4 == ".ppm") {
+            try
+            {
+                return load_ppm_file(filename);
+            }
+            catch (util::FileException& e) { throw; }
+            catch (util::Exception& e) {}
+        }
 
         try
         {
@@ -106,27 +122,37 @@ load_file (std::string const& filename)
 ImageHeaders
 load_file_headers (std::string const& filename)
 {
+    using namespace util::string;
+    std::string fext4 = lowercase(right(filename, 4));
+    std::string fext5 = lowercase(right(filename, 5));
+
     try
     {
 #ifndef MVE_NO_PNG_SUPPORT
-        try
-        { return load_png_file_headers(filename); }
-        catch (util::FileException&) { throw; }
-        catch (util::Exception&) {}
+        if (fext4 == ".png"){
+            try
+            { return load_png_file_headers(filename); }
+            catch (util::FileException&) { throw; }
+            catch (util::Exception&) {}
+        }
 #endif
 
 #ifndef MVE_NO_JPEG_SUPPORT
-        try
-        { return load_jpg_file_headers(filename); }
-        catch (util::FileException&) { throw; }
-        catch (util::Exception&) {}
+        if (fext4 == ".jpg" || fext5 == ".jpeg"){
+            try
+            { return load_jpg_file_headers(filename); }
+            catch (util::FileException&) { throw; }
+            catch (util::Exception&) {}
+        }
 #endif
 
 #ifndef MVE_NO_TIFF_SUPPORT
-        try
-        { return load_tiff_file_headers(filename); }
-        catch (util::FileException&) { throw; }
-        catch (util::Exception&) {}
+        if (fext4 == ".tif" || fext5 == ".tiff"){
+            try
+            { return load_tiff_file_headers(filename); }
+            catch (util::FileException&) { throw; }
+            catch (util::Exception&) {}
+        }
 #endif
 
         try


### PR DESCRIPTION
Hello :hand: !

This PR proposes to add checking to file extensions before attempting to load a file. Aside from the modest speed improvement, this solves a deeper issue of leaking file descriptors with JPG files (which happens if you load TIFFs or ppm or mvei, due to the order in which file formats are tried).

The root cause of the leaks is that attempting to read an invalid JPG file (e.g. a TIFF file) will trigger the error callback in https://github.com/simonfuhrmann/mve/blob/master/libs/mve/image_io.cc#L467 `jpg_error_handler`, but because the function is a library call, the util::Exception triggered in the callback is not caught by the catch-all function block, and is instead caught further up the stack, causing `fp` to never be closed.

This doesn't explicitly fix the leak (I'm unsure of a good way to handle this gracefully), but the extension check is a nice way to avoid trying to open obvious files with the wrong reader (and mitigates the leak).﻿
