### PR TITLE
SFM: Guard inclusion of SSE headers

### DIFF
--- a/libs/sfm/nearest_neighbor.cc
+++ b/libs/sfm/nearest_neighbor.cc
@@ -39,8 +39,12 @@
 
 #include <algorithm>
 #include <iostream>
-#include <emmintrin.h> // SSE2
-#include <pmmintrin.h> // SSE3
+#if defined(__SSE2__)
+#   include <emmintrin.h> // SSE2
+#endif
+#if defined(__SSE3__)
+#   include <pmmintrin.h> // SSE3
+#endif
 
 #include "sfm/nearest_neighbor.h"
 


### PR DESCRIPTION
Fixes compilation for CPUs that don't support SSE2/3.

Fixes #572