### PR TITLE
MVE: Don't hardcode vsnprintf() destination buffer size

### DIFF
--- a/libs/mve/image_io.cc
+++ b/libs/mve/image_io.cc
@@ -631,7 +631,7 @@ void
 tiff_error_handler (char const* /*module*/, char const* fmt, va_list ap)
 {
     char msg[2048];
-    ::vsnprintf(msg, 2048, fmt, ap);
+    ::vsnprintf(msg, sizeof(msg), fmt, ap);
     throw util::Exception(msg);
 }
 


### PR DESCRIPTION
This MR contains a minor improvement to a vsnprintf() call which was introduced in a recent commit.