### PR TITLE
UMVE: Raise C++ version to C++14

### DIFF
--- a/apps/umve/umve.pro
+++ b/apps/umve/umve.pro
@@ -1,6 +1,6 @@
 MVE_ROOT = ../..
 
-CONFIG += link_pkgconfig qt release c++11
+CONFIG += link_pkgconfig qt release c++14
 PKGCONFIG += libjpeg libpng libtiff-4
 QT += concurrent opengl
 


### PR DESCRIPTION
The C++ version of MVE was raised to C++14 in a previous commit and UMVE was missed.