### PR TITLE
Update macOS CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
         - { name: "Ubuntu 24.04, Clang, x86_64", os: ubuntu-24.04, cpp_compiler: clang++, qmake_spec: linux-clang }
         - { name: "macOS 13, Clang, x86_64",     os: macos-13,     cpp_compiler: clang++, qmake_spec: macx-clang }
         - { name: "macOS 14, Clang, arm64",      os: macos-14,     cpp_compiler: clang++, qmake_spec: macx-clang }
+        - { name: "macOS 15, Clang, arm64",      os: macos-15,     cpp_compiler: clang++, qmake_spec: macx-clang }
 
     env:
       CXX: ${{ matrix.platform.cpp_compiler }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,6 @@ jobs:
         - { name: "Ubuntu 22.04, Clang, x86_64", os: ubuntu-22.04, cpp_compiler: clang++, qmake_spec: linux-clang }
         - { name: "Ubuntu 24.04, GCC, x86_64",   os: ubuntu-24.04, cpp_compiler: g++,     qmake_spec: linux-g++ }
         - { name: "Ubuntu 24.04, Clang, x86_64", os: ubuntu-24.04, cpp_compiler: clang++, qmake_spec: linux-clang }
-        - { name: "macOS 12, Clang, x86_64",     os: macos-12,     cpp_compiler: clang++, qmake_spec: macx-clang }
         - { name: "macOS 13, Clang, x86_64",     os: macos-13,     cpp_compiler: clang++, qmake_spec: macx-clang }
         - { name: "macOS 14, Clang, arm64",      os: macos-14,     cpp_compiler: clang++, qmake_spec: macx-clang }
 


### PR DESCRIPTION
Hi,
this PR updates the macOS CI by removing the macOS 12 CI pipeline because the runner image has been deprecated since 3rd December 2024 and adding a macOS 15 CI pipeline.
