### PR TITLE
switch to c++17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,13 +25,10 @@ jobs:
 
       matrix:
         platform:
-        - { name: "Ubuntu 20.04, GCC, x86_64",   os: ubuntu-20.04, cpp_compiler: g++,     qmake_spec: linux-g++ }
-        - { name: "Ubuntu 20.04, Clang, x86_64", os: ubuntu-20.04, cpp_compiler: clang++, qmake_spec: linux-clang }
         - { name: "Ubuntu 22.04, GCC, x86_64",   os: ubuntu-22.04, cpp_compiler: g++,     qmake_spec: linux-g++ }
         - { name: "Ubuntu 22.04, Clang, x86_64", os: ubuntu-22.04, cpp_compiler: clang++, qmake_spec: linux-clang }
         - { name: "Ubuntu 24.04, GCC, x86_64",   os: ubuntu-24.04, cpp_compiler: g++,     qmake_spec: linux-g++ }
         - { name: "Ubuntu 24.04, Clang, x86_64", os: ubuntu-24.04, cpp_compiler: clang++, qmake_spec: linux-clang }
-        - { name: "macOS 13, Clang, x86_64",     os: macos-13,     cpp_compiler: clang++, qmake_spec: macx-clang }
         - { name: "macOS 14, Clang, arm64",      os: macos-14,     cpp_compiler: clang++, qmake_spec: macx-clang }
         - { name: "macOS 15, Clang, arm64",      os: macos-15,     cpp_compiler: clang++, qmake_spec: macx-clang }
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,15 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  workflow_dispatch:
+  schedule:
+    # every 1st day of month at 00:00 UTC
+    - cron: "0 0 1 * *"
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,8 @@ on:
 
 permissions:
   contents: read
-  checks: write
-  pull-requests: write
+  checks: read
+  pull-requests: read
 
 jobs:
   build:

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -2,7 +2,7 @@
 CXX ?= g++
 CXXWARNINGS ?= -Wall -Wextra -Wundef -pedantic
 CXXINTRINSICS ?= -march=native
-CXXFEATURES ?= -funsafe-math-optimizations -fno-math-errno -std=c++14
+CXXFEATURES ?= -funsafe-math-optimizations -fno-math-errno -std=c++17
 CXXFLAGS ?= ${CXXWARNINGS} ${CXXINTRINSICS} ${CXXFEATURES} -g -O3
 
 # Delete this if OpenMP is not available (e.g., OS X without gcc)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,7 +8,7 @@ GTEST_LDFLAGS = `pkg-config --libs gtest_main`
 SOURCES = $(wildcard math/gtest_*.cc) $(wildcard mve/gtest_*.cc) $(wildcard sfm/gtest_*.cc) $(wildcard util/gtest_*.cc) $(wildcard fssr/gtest_*.cc)
 INCLUDES = -I${MVE_ROOT}/libs ${GTEST_CFLAGS}
 CXXWARNINGS = -Wall -Wextra -pedantic -Wno-sign-compare
-CXXFLAGS = -std=c++14 -pthread ${CXXWARNINGS} ${INCLUDES}
+CXXFLAGS = -std=c++17 -pthread ${CXXWARNINGS} ${INCLUDES}
 LDLIBS += ${GTEST_LDFLAGS} ${LIBJPEG_LDFLAGS} ${LIBPNG_LDFLAGS} ${LIBTIFF_LDFLAGS}
 
 test: ${SOURCES:.cc=.o} libmve_fssr.a libmve_sfm.a libmve.a libmve_util.a


### PR DESCRIPTION
Switch to c++17 standard as recent versions of GTest require it. The CI on macos was failing because homebrew pulls such versions.

Incidentally, 
- added permissions to the workflow
- set a monthly schedule for automatically triggering the workflow 