### PR TITLE
CI: Update actions/checkout to v6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       QMAKE_SPEC: ${{ matrix.platform.qmake_spec }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install Ubuntu dependencies
       if: runner.os == 'Linux'


### PR DESCRIPTION
This MR updates `actions/checkout` in the CI pipelines to v6 to fix a warning about Actions still using Node.js 20 because [Actions will be forced to use Node.js 24 on June 2nd, 2026](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) and `actions/checkout` v4 still uses Node.js 20. Additionally, this will keep the CI pipelines working when Node.js 20 will be removed from GitHub's runners in the fall of 2026.